### PR TITLE
refactor!: migrate from `thiserror` to `snafu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1" }
-thiserror = { version = "1", default-features = false }
+snafu = { version = "0.8.4", default-features = false }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 # tokio = { version = "1.39.3" }
 tracing = { version = "0.1.36" }

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -20,7 +20,7 @@ bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 lalrpop-util = { workspace = true, features = ["lexer", "unicode"] }
 serde = { workspace = true, features = ["serde_derive", "alloc"] }
-thiserror = { workspace = true }
+snafu = { workspace = true }
 
 [build-dependencies]
 lalrpop = { workspace = true }

--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -1,22 +1,22 @@
 use alloc::string::String;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors encountered during the parsing process
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, Snafu, Eq, PartialEq)]
 pub enum ParseError {
-    #[error("Unable to parse query")]
+    #[snafu(display("Unable to parse query"))]
     /// Cannot parse the query
     QueryParseError {
         /// The underlying error
         error: String,
     },
-    #[error("Unable to parse identifier")]
+    #[snafu(display("Unable to parse identifier"))]
     /// Cannot parse the identifier
     IdentifierParseError {
         /// The underlying error
         error: String,
     },
-    #[error("Unable to parse resource_id")]
+    #[snafu(display("Unable to parse resource_id"))]
     /// Can not parse the resource_id
     ResourceIdParseError {
         /// The underlying error

--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -6,13 +6,22 @@ use thiserror::Error;
 pub enum ParseError {
     #[error("Unable to parse query")]
     /// Cannot parse the query
-    QueryParseError(String),
+    QueryParseError {
+        /// The underlying error
+        error: String,
+    },
     #[error("Unable to parse identifier")]
     /// Cannot parse the identifier
-    IdentifierParseError(String),
+    IdentifierParseError {
+        /// The underlying error
+        error: String,
+    },
     #[error("Unable to parse resource_id")]
     /// Can not parse the resource_id
-    ResourceIdParseError(String),
+    ResourceIdParseError {
+        /// The underlying error
+        error: String,
+    },
 }
 
 /// General parsing error that may occur, for example if the provided schema/object_name strings

--- a/crates/proof-of-sql-parser/src/identifier.rs
+++ b/crates/proof-of-sql-parser/src/identifier.rs
@@ -45,8 +45,8 @@ impl FromStr for Identifier {
     fn from_str(string: &str) -> ParseResult<Self> {
         let name = IdentifierParser::new()
             .parse(string)
-            .map_err(|e| ParseError::IdentifierParseError(
-                format!("failed to parse identifier, (you may have used a reserved keyword as an ID, i.e. 'timestamp') {:?}", e)))?;
+            .map_err(|e| ParseError::IdentifierParseError{ error:
+                format!("failed to parse identifier, (you may have used a reserved keyword as an ID, i.e. 'timestamp') {:?}", e)})?;
 
         Ok(Identifier::new(name))
     }

--- a/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
@@ -1323,18 +1323,18 @@ fn we_cannot_parse_literals_outside_of_i128_range_in_the_result_expr() {
         .is_ok());
     assert_eq!(
         "select 170141183460469231731687303715884105728 from tab".parse::<SelectStatement>(),
-        Err(super::error::ParseError::QueryParseError(
-            "i128 out of range".to_string()
-        ))
+        Err(super::error::ParseError::QueryParseError {
+            error: "i128 out of range".to_string()
+        })
     );
     assert!("select -170141183460469231731687303715884105728 from tab"
         .parse::<SelectStatement>()
         .is_ok());
     assert_eq!(
         "select -170141183460469231731687303715884105729 from tab".parse::<SelectStatement>(),
-        Err(super::error::ParseError::QueryParseError(
-            "i128 out of range".to_string()
-        ))
+        Err(super::error::ParseError::QueryParseError {
+            error: "i128 out of range".to_string()
+        })
     );
 }
 

--- a/crates/proof-of-sql-parser/src/intermediate_decimal.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_decimal.rs
@@ -10,25 +10,25 @@ use alloc::string::String;
 use bigdecimal::{num_bigint::BigInt, BigDecimal, ParseBigDecimalError, ToPrimitive};
 use core::{fmt, hash::Hash, str::FromStr};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors related to the processing of decimal values in proof-of-sql
-#[derive(Error, Debug, PartialEq)]
+#[derive(Snafu, Debug, PartialEq)]
 pub enum IntermediateDecimalError {
     /// Represents an error encountered during the parsing of a decimal string.
-    #[error("{error}")]
+    #[snafu(display("{error}"))]
     ParseError {
         /// The underlying error
         error: ParseBigDecimalError,
     },
     /// Error occurs when this decimal cannot fit in a primitive.
-    #[error("Value out of range for target type")]
+    #[snafu(display("Value out of range for target type"))]
     OutOfRange,
     /// Error occurs when this decimal cannot be losslessly cast into a primitive.
-    #[error("Fractional part of decimal is non-zero")]
+    #[snafu(display("Fractional part of decimal is non-zero"))]
     LossyCast,
     /// Cannot cast this decimal to a big integer
-    #[error("Conversion to integer failed")]
+    #[snafu(display("Conversion to integer failed"))]
     ConversionFailure,
 }
 impl From<ParseBigDecimalError> for IntermediateDecimalError {

--- a/crates/proof-of-sql-parser/src/intermediate_decimal.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_decimal.rs
@@ -16,8 +16,11 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq)]
 pub enum IntermediateDecimalError {
     /// Represents an error encountered during the parsing of a decimal string.
-    #[error("{0}")]
-    ParseError(ParseBigDecimalError),
+    #[error("{error}")]
+    ParseError {
+        /// The underlying error
+        error: ParseBigDecimalError,
+    },
     /// Error occurs when this decimal cannot fit in a primitive.
     #[error("Value out of range for target type")]
     OutOfRange,
@@ -30,7 +33,7 @@ pub enum IntermediateDecimalError {
 }
 impl From<ParseBigDecimalError> for IntermediateDecimalError {
     fn from(value: ParseBigDecimalError) -> Self {
-        IntermediateDecimalError::ParseError(value)
+        IntermediateDecimalError::ParseError { error: value }
     }
 }
 
@@ -88,7 +91,7 @@ impl FromStr for IntermediateDecimal {
             .map(|value| IntermediateDecimal {
                 value: value.normalized(),
             })
-            .map_err(ParseError)
+            .map_err(|err| ParseError { error: err })
     }
 }
 

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -6,8 +6,11 @@ use thiserror::Error;
 #[derive(Error, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.
-    #[error("invalid timezone string: {0}")]
-    InvalidTimezone(String),
+    #[error("invalid timezone string: {timezone}")]
+    InvalidTimezone {
+        /// The invalid timezone
+        timezone: String,
+    },
 
     /// Error indicating an invalid timezone offset was provided.
     #[error("invalid timezone offset")]
@@ -15,7 +18,10 @@ pub enum PoSQLTimestampError {
 
     /// Indicates a failure to convert between different representations of time units.
     #[error("Invalid time unit")]
-    InvalidTimeUnit(String),
+    InvalidTimeUnit {
+        /// The underlying error
+        error: String,
+    },
 
     /// The local time does not exist because there is a gap in the local time.
     /// This variant may also be returned if there was an error while resolving the local time,
@@ -26,16 +32,25 @@ pub enum PoSQLTimestampError {
     /// The local time is ambiguous because there is a fold in the local time.
     /// This variant contains the two possible results, in the order (earliest, latest).
     #[error("Unix timestamp is ambiguous because there is a fold in the local time.")]
-    Ambiguous(String),
+    Ambiguous {
+        /// The underlying error
+        error: String,
+    },
 
     /// Represents a catch-all for parsing errors not specifically covered by other variants.
-    #[error("Timestamp parsing error: {0}")]
-    ParsingError(String),
+    #[error("Timestamp parsing error: {error}")]
+    ParsingError {
+        /// The underlying error
+        error: String,
+    },
 
     /// Represents a failure to parse a provided time unit precision value, PoSQL supports
     /// Seconds, Milliseconds, Microseconds, and Nanoseconds
-    #[error("Timestamp parsing error: {0}")]
-    UnsupportedPrecision(String),
+    #[error("Timestamp parsing error: {error}")]
+    UnsupportedPrecision {
+        /// The underlying error
+        error: String,
+    },
 }
 
 // This exists because TryFrom<DataType> for ColumnType error is String

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -1,23 +1,23 @@
 use alloc::string::{String, ToString};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors related to time operations, including timezone and timestamp conversions.s
-#[derive(Error, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.
-    #[error("invalid timezone string: {timezone}")]
+    #[snafu(display("invalid timezone string: {timezone}"))]
     InvalidTimezone {
         /// The invalid timezone
         timezone: String,
     },
 
     /// Error indicating an invalid timezone offset was provided.
-    #[error("invalid timezone offset")]
+    #[snafu(display("invalid timezone offset"))]
     InvalidTimezoneOffset,
 
     /// Indicates a failure to convert between different representations of time units.
-    #[error("Invalid time unit")]
+    #[snafu(display("Invalid time unit"))]
     InvalidTimeUnit {
         /// The underlying error
         error: String,
@@ -26,19 +26,19 @@ pub enum PoSQLTimestampError {
     /// The local time does not exist because there is a gap in the local time.
     /// This variant may also be returned if there was an error while resolving the local time,
     /// caused by for example missing time zone data files, an error in an OS API, or overflow.
-    #[error("Local time does not exist because there is a gap in the local time")]
+    #[snafu(display("Local time does not exist because there is a gap in the local time"))]
     LocalTimeDoesNotExist,
 
     /// The local time is ambiguous because there is a fold in the local time.
     /// This variant contains the two possible results, in the order (earliest, latest).
-    #[error("Unix timestamp is ambiguous because there is a fold in the local time.")]
+    #[snafu(display("Unix timestamp is ambiguous because there is a fold in the local time."))]
     Ambiguous {
         /// The underlying error
         error: String,
     },
 
     /// Represents a catch-all for parsing errors not specifically covered by other variants.
-    #[error("Timestamp parsing error: {error}")]
+    #[snafu(display("Timestamp parsing error: {error}"))]
     ParsingError {
         /// The underlying error
         error: String,
@@ -46,7 +46,7 @@ pub enum PoSQLTimestampError {
 
     /// Represents a failure to parse a provided time unit precision value, PoSQL supports
     /// Seconds, Milliseconds, Microseconds, and Nanoseconds
-    #[error("Timestamp parsing error: {error}")]
+    #[snafu(display("Timestamp parsing error: {error}"))]
     UnsupportedPrecision {
         /// The underlying error
         error: String,

--- a/crates/proof-of-sql-parser/src/posql_time/timezone.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timezone.rs
@@ -45,7 +45,9 @@ impl TryFrom<&Option<Arc<str>>> for PoSQLTimeZone {
                         let total_seconds = sign * ((hours * 3600) + (minutes * 60));
                         Ok(PoSQLTimeZone::FixedOffset(total_seconds))
                     }
-                    _ => Err(PoSQLTimestampError::InvalidTimezone(tz.to_string())),
+                    _ => Err(PoSQLTimestampError::InvalidTimezone {
+                        timezone: tz.to_string(),
+                    }),
                 }
             }
             None => Ok(PoSQLTimeZone::Utc),

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -23,7 +23,9 @@ impl TryFrom<&str> for PoSQLTimeUnit {
             "3" => Ok(PoSQLTimeUnit::Millisecond),
             "6" => Ok(PoSQLTimeUnit::Microsecond),
             "9" => Ok(PoSQLTimeUnit::Nanosecond),
-            _ => Err(PoSQLTimestampError::UnsupportedPrecision(value.into())),
+            _ => Err(PoSQLTimestampError::UnsupportedPrecision {
+                error: value.into(),
+            }),
         }
     }
 }
@@ -65,7 +67,7 @@ mod time_unit_tests {
             let result = PoSQLTimeUnit::try_from(value);
             assert!(matches!(
                 result,
-                Err(PoSQLTimestampError::UnsupportedPrecision(_))
+                Err(PoSQLTimestampError::UnsupportedPrecision { .. })
             ));
         }
     }

--- a/crates/proof-of-sql-parser/src/resource_id.rs
+++ b/crates/proof-of-sql-parser/src/resource_id.rs
@@ -91,9 +91,11 @@ impl FromStr for ResourceId {
     type Err = ParseError;
 
     fn from_str(string: &str) -> ParseResult<Self> {
-        let (schema, object_name) = ResourceIdParser::new()
-            .parse(string)
-            .map_err(|e| ParseError::ResourceIdParseError(format!("{:?}", e)))?;
+        let (schema, object_name) = ResourceIdParser::new().parse(string).map_err(|e| {
+            ParseError::ResourceIdParseError {
+                error: format!("{:?}", e),
+            }
+        })?;
 
         // use unsafe `Identifier::new` to prevent double parsing the ids
         Ok(ResourceId {

--- a/crates/proof-of-sql-parser/src/select_statement.rs
+++ b/crates/proof-of-sql-parser/src/select_statement.rs
@@ -62,7 +62,9 @@ impl FromStr for SelectStatement {
     fn from_str(query: &str) -> ParseResult<Self> {
         SelectStatementParser::new()
             .parse(query)
-            .map_err(|e| ParseError::QueryParseError(e.to_string()))
+            .map_err(|e| ParseError::QueryParseError {
+                error: e.to_string(),
+            })
     }
 }
 

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -75,6 +75,7 @@ development = ["arrow-csv"]
 default = ["arrow", "blitzar"]
 arrow = ["dep:arrow"]
 test = ["dep:rand"]
+std = ["snafu/std"]
 
 [lints]
 workspace = true
@@ -85,7 +86,7 @@ required-features = [ "blitzar", "test" ]
 
 [[example]]
 name = "posql_db"
-required-features = [ "arrow", "blitzar" ]
+required-features = [ "arrow", "blitzar", "std" ]
 
 [[bench]]
 name = "posql_benches"

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -44,7 +44,7 @@ rand = { workspace = true, default-features = false, optional = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
+snafu = { workspace = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -1,11 +1,11 @@
 use super::committable_column::CommittableColumn;
 use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Cannot construct bounds where min is greater than max.
-#[derive(Error, Debug)]
-#[error("cannot construct bounds where min is greater than max")]
+#[derive(Snafu, Debug)]
+#[snafu(display("cannot construct bounds where min is greater than max"))]
 pub struct NegativeBounds;
 
 /// Inner value for [`Bounds::Sharp`] and [`Bounds::Bounded`].
@@ -187,8 +187,10 @@ where
 }
 
 /// Columns with different [`ColumnBounds`] variants cannot operate with each other.
-#[derive(Debug, Error)]
-#[error("column with bounds {bounds_a:?} cannot operate with column with bounds {bounds_b:?}")]
+#[derive(Debug, Snafu)]
+#[snafu(display(
+    "column with bounds {bounds_a:?} cannot operate with column with bounds {bounds_b:?}"
+))]
 pub struct ColumnBoundsMismatch {
     bounds_a: Box<ColumnBounds>,
     bounds_b: Box<ColumnBounds>,

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -188,8 +188,11 @@ where
 
 /// Columns with different [`ColumnBounds`] variants cannot operate with each other.
 #[derive(Debug, Error)]
-#[error("column with bounds {0:?} cannot operate with column with bounds {1:?}")]
-pub struct ColumnBoundsMismatch(Box<ColumnBounds>, Box<ColumnBounds>);
+#[error("column with bounds {bounds_a:?} cannot operate with column with bounds {bounds_b:?}")]
+pub struct ColumnBoundsMismatch {
+    bounds_a: Box<ColumnBounds>,
+    bounds_b: Box<ColumnBounds>,
+}
 
 /// Column metadata storing the bounds for column types that have order.
 ///
@@ -254,9 +257,10 @@ impl ColumnBounds {
             (ColumnBounds::Int128(bounds_a), ColumnBounds::Int128(bounds_b)) => {
                 Ok(ColumnBounds::Int128(bounds_a.union(bounds_b)))
             }
-            (bounds_a, bounds_b) => {
-                Err(ColumnBoundsMismatch(Box::new(bounds_a), Box::new(bounds_b)))
-            }
+            (bounds_a, bounds_b) => Err(ColumnBoundsMismatch {
+                bounds_a: Box::new(bounds_a),
+                bounds_b: Box::new(bounds_b),
+            }),
         }
     }
 
@@ -282,7 +286,10 @@ impl ColumnBounds {
             (ColumnBounds::TimestampTZ(bounds_a), ColumnBounds::TimestampTZ(bounds_b)) => {
                 Ok(ColumnBounds::TimestampTZ(bounds_a.difference(bounds_b)))
             }
-            (_, _) => Err(ColumnBoundsMismatch(Box::new(self), Box::new(other))),
+            (_, _) => Err(ColumnBoundsMismatch {
+                bounds_a: Box::new(self),
+                bounds_b: Box::new(other),
+            }),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -2,13 +2,13 @@ use super::{column_bounds::BoundsInner, committable_column::CommittableColumn, C
 use crate::base::database::ColumnType;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors that can occur when constructing invalid [`ColumnCommitmentMetadata`].
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum InvalidColumnCommitmentMetadata {
     /// Column of this type cannot have these bounds.
-    #[error("column of type {column_type} cannot have bounds like {column_bounds:?}")]
+    #[snafu(display("column of type {column_type} cannot have bounds like {column_bounds:?}"))]
     TypeBoundsMismatch {
         column_type: ColumnType,
         column_bounds: ColumnBounds,
@@ -16,8 +16,10 @@ pub enum InvalidColumnCommitmentMetadata {
 }
 
 /// During column operation, metadata indicates that the operand columns cannot be the same.
-#[derive(Debug, Error)]
-#[error("column with type {datatype_a} cannot operate with column with type {datatype_b}")]
+#[derive(Debug, Snafu)]
+#[snafu(display(
+    "column with type {datatype_a} cannot operate with column with type {datatype_b}"
+))]
 pub struct ColumnCommitmentMetadataMismatch {
     datatype_a: ColumnType,
     datatype_b: ColumnType,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -6,28 +6,29 @@ use crate::base::database::ColumnField;
 use alloc::string::{String, ToString};
 use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Mapping of column identifiers to column metadata used to associate metadata with commitments.
 pub type ColumnCommitmentMetadataMap = IndexMap<Identifier, ColumnCommitmentMetadata>;
 
 /// During commitment operation, metadata indicates that operand tables cannot be the same.
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum ColumnCommitmentsMismatch {
     /// Anonymous metadata indicates a column mismatch.
-    #[error(transparent)]
+    #[snafu(transparent)]
     ColumnCommitmentMetadata {
         /// The underlying source error
-        #[from]
         source: ColumnCommitmentMetadataMismatch,
     },
     /// Commitments with different column counts cannot operate with each other.
-    #[error("commitments with different column counts cannot operate with each other")]
+    #[snafu(display("commitments with different column counts cannot operate with each other"))]
     NumColumns,
     /// Columns with mismatched identifiers cannot operate with each other.
     ///
     /// Strings are used here instead of Identifiers to decrease the size of this variant
-    #[error("column with identifier {id_a} cannot operate with column with identifier {id_b}")]
+    #[snafu(display(
+        "column with identifier {id_a} cannot operate with column with identifier {id_b}"
+    ))]
     Identifier {
         /// The first column identifier
         id_a: String,

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -13,30 +13,28 @@ use core::{iter, slice};
 use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Cannot create commitments with duplicate identifier.
-#[derive(Debug, Error)]
-#[error("cannot create commitments with duplicate identifier: {id}")]
+#[derive(Debug, Snafu)]
+#[snafu(display("cannot create commitments with duplicate identifier: {id}"))]
 pub struct DuplicateIdentifiers {
     id: String,
 }
 
 /// Errors that can occur when attempting to append rows to ColumnCommitments.
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum AppendColumnCommitmentsError {
     /// Metadata between new and old columns are mismatched.
-    #[error(transparent)]
+    #[snafu(transparent)]
     Mismatch {
         /// The underlying source error
-        #[from]
         source: ColumnCommitmentsMismatch,
     },
     /// New columns have duplicate identifiers.
-    #[error(transparent)]
+    #[snafu(transparent)]
     DuplicateIdentifiers {
         /// The underlying source error
-        #[from]
         source: DuplicateIdentifiers,
     },
 }

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -17,18 +17,28 @@ use thiserror::Error;
 
 /// Cannot create commitments with duplicate identifier.
 #[derive(Debug, Error)]
-#[error("cannot create commitments with duplicate identifier: {0}")]
-pub struct DuplicateIdentifiers(String);
+#[error("cannot create commitments with duplicate identifier: {id}")]
+pub struct DuplicateIdentifiers {
+    id: String,
+}
 
 /// Errors that can occur when attempting to append rows to ColumnCommitments.
 #[derive(Debug, Error)]
 pub enum AppendColumnCommitmentsError {
     /// Metadata between new and old columns are mismatched.
     #[error(transparent)]
-    Mismatch(#[from] ColumnCommitmentsMismatch),
+    Mismatch {
+        /// The underlying source error
+        #[from]
+        source: ColumnCommitmentsMismatch,
+    },
     /// New columns have duplicate identifiers.
     #[error(transparent)]
-    DuplicateIdentifiers(#[from] DuplicateIdentifiers),
+    DuplicateIdentifiers {
+        /// The underlying source error
+        #[from]
+        source: DuplicateIdentifiers,
+    },
 }
 
 /// Commitments for a collection of columns with some metadata.
@@ -118,7 +128,9 @@ impl<C: Commitment> ColumnCommitments<C> {
                 if unique_identifiers.insert(identifier) {
                     Ok((identifier, column))
                 } else {
-                    Err(DuplicateIdentifiers(identifier.to_string()))
+                    Err(DuplicateIdentifiers {
+                        id: identifier.to_string(),
+                    })
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -168,7 +180,9 @@ impl<C: Commitment> ColumnCommitments<C> {
                 if unique_identifiers.insert(identifier) {
                     Ok((identifier, column))
                 } else {
-                    Err(DuplicateIdentifiers(identifier.to_string()))
+                    Err(DuplicateIdentifiers {
+                        id: identifier.to_string(),
+                    })
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -216,7 +230,9 @@ impl<C: Commitment> ColumnCommitments<C> {
             .into_iter()
             .map(|(identifier, column)| {
                 if self.column_metadata.contains_key(identifier) {
-                    Err(DuplicateIdentifiers(identifier.to_string()))
+                    Err(DuplicateIdentifiers {
+                        id: identifier.to_string(),
+                    })
                 } else {
                     Ok((identifier, column))
                 }
@@ -469,7 +485,10 @@ mod tests {
             0,
             &(),
         );
-        assert!(matches!(from_columns_result, Err(DuplicateIdentifiers(_))));
+        assert!(matches!(
+            from_columns_result,
+            Err(DuplicateIdentifiers { .. })
+        ));
 
         let mut existing_column_commitments =
             ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
@@ -486,7 +505,7 @@ mod tests {
             .try_extend_columns_with_offset([(&duplicate_identifier_a, &empty_column)], 0, &());
         assert!(matches!(
             extend_with_existing_column_result,
-            Err(DuplicateIdentifiers(_))
+            Err(DuplicateIdentifiers { .. })
         ));
 
         let extend_with_duplicate_columns_result = existing_column_commitments
@@ -500,7 +519,7 @@ mod tests {
             );
         assert!(matches!(
             extend_with_duplicate_columns_result,
-            Err(DuplicateIdentifiers(_))
+            Err(DuplicateIdentifiers { .. })
         ));
 
         let append_result = existing_column_commitments.try_append_rows_with_offset(
@@ -514,7 +533,7 @@ mod tests {
         );
         assert!(matches!(
             append_result,
-            Err(AppendColumnCommitmentsError::DuplicateIdentifiers(_))
+            Err(AppendColumnCommitmentsError::DuplicateIdentifiers { .. })
         ));
     }
 
@@ -627,9 +646,9 @@ mod tests {
         ]);
         assert!(matches!(
             base_commitments.try_append_rows_with_offset(table_diff_type.inner_table(), 4, &()),
-            Err(AppendColumnCommitmentsError::Mismatch(
-                ColumnCommitmentsMismatch::ColumnCommitmentMetadata(_)
-            ))
+            Err(AppendColumnCommitmentsError::Mismatch {
+                source: ColumnCommitmentsMismatch::ColumnCommitmentMetadata { .. }
+            })
         ));
 
         let table_diff_id: OwnedTable<Curve25519Scalar> = owned_table([
@@ -642,18 +661,18 @@ mod tests {
         );
         assert!(matches!(
             base_commitments.try_append_rows_with_offset(table_diff_id.inner_table(), 4, &()),
-            Err(AppendColumnCommitmentsError::Mismatch(
-                ColumnCommitmentsMismatch::Identifier(..)
-            ))
+            Err(AppendColumnCommitmentsError::Mismatch {
+                source: ColumnCommitmentsMismatch::Identifier { .. }
+            })
         ));
 
         let table_diff_len: OwnedTable<Curve25519Scalar> =
             owned_table([bigint("column_a", [5, 6, 7, 8])]);
         assert!(matches!(
             base_commitments.try_append_rows_with_offset(table_diff_len.inner_table(), 4, &()),
-            Err(AppendColumnCommitmentsError::Mismatch(
-                ColumnCommitmentsMismatch::NumColumns
-            ))
+            Err(AppendColumnCommitmentsError::Mismatch {
+                source: ColumnCommitmentsMismatch::NumColumns
+            })
         ));
     }
 
@@ -768,7 +787,7 @@ mod tests {
                 .unwrap();
         assert!(matches!(
             base_commitments.clone().try_add(commitments_diff_type),
-            Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata(_))
+            Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata { .. })
         ));
 
         let table_diff_id: OwnedTable<Curve25519Scalar> = owned_table([
@@ -780,7 +799,7 @@ mod tests {
                 .unwrap();
         assert!(matches!(
             base_commitments.clone().try_add(commitments_diff_id),
-            Err(ColumnCommitmentsMismatch::Identifier(..))
+            Err(ColumnCommitmentsMismatch::Identifier { .. })
         ));
 
         let table_diff_len: OwnedTable<Curve25519Scalar> =
@@ -896,7 +915,7 @@ mod tests {
                 .unwrap();
         assert!(matches!(
             minuend_commitments.clone().try_sub(commitments_diff_type),
-            Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata(_))
+            Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata { .. })
         ));
 
         let table_diff_id: OwnedTable<Curve25519Scalar> =
@@ -906,7 +925,7 @@ mod tests {
                 .unwrap();
         assert!(matches!(
             minuend_commitments.clone().try_sub(commitments_diff_id),
-            Err(ColumnCommitmentsMismatch::Identifier(..))
+            Err(ColumnCommitmentsMismatch::Identifier { .. })
         ));
 
         let table_diff_len: OwnedTable<Curve25519Scalar> =

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -15,114 +15,106 @@ use bumpalo::Bump;
 use core::ops::Range;
 use proof_of_sql_parser::{Identifier, ParseError};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Cannot create a [`TableCommitment`] with a negative range.
-#[derive(Debug, Error)]
-#[error("cannot create a TableCommitment with a negative range")]
+#[derive(Debug, Snafu)]
+#[snafu(display("cannot create a TableCommitment with a negative range"))]
 pub struct NegativeRange;
 
 /// Cannot create a [`TableCommitment`] from columns of mixed length.
-#[derive(Debug, Error)]
-#[error("cannot create a TableCommitment from columns of mixed length")]
+#[derive(Debug, Snafu)]
+#[snafu(display("cannot create a TableCommitment from columns of mixed length"))]
 pub struct MixedLengthColumns;
 
 /// Errors that can occur when trying to create or extend a [`TableCommitment`] from columns.
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum TableCommitmentFromColumnsError {
     /// Cannot construct [`TableCommitment`] from columns of mixed length.
-    #[error(transparent)]
+    #[snafu(transparent)]
     MixedLengthColumns {
         /// The underlying source error
-        #[from]
         source: MixedLengthColumns,
     },
     /// Cannot construct [`TableCommitment`] from columns with duplicate identifiers.
-    #[error(transparent)]
+    #[snafu(transparent)]
     DuplicateIdentifiers {
         /// The underlying source error
-        #[from]
         source: DuplicateIdentifiers,
     },
 }
 
 /// Errors that can occur when attempting to append rows to a [`TableCommitment`].
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum AppendTableCommitmentError {
     /// Cannot append columns of mixed length to existing [`TableCommitment`].
-    #[error(transparent)]
+    #[snafu(transparent)]
     MixedLengthColumns {
         /// The underlying source error
-        #[from]
         source: MixedLengthColumns,
     },
     /// Encountered error when appending internal [`ColumnCommitments`].
-    #[error(transparent)]
+    #[snafu(transparent)]
     AppendColumnCommitments {
         /// The underlying source error
-        #[from]
         source: AppendColumnCommitmentsError,
     },
 }
 
 /// Errors that can occur when performing arithmetic on [`TableCommitment`]s.
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum TableCommitmentArithmeticError {
     /// Cannot perform arithmetic on columns with mismatched metadata.
-    #[error(transparent)]
+    #[snafu(transparent)]
     ColumnMismatch {
         /// The underlying source error
-        #[from]
         source: ColumnCommitmentsMismatch,
     },
     /// Cannot perform TableCommitment arithmetic that would result in a negative range.
-    #[error(transparent)]
+    #[snafu(transparent)]
     NegativeRange {
         /// The underlying source error
-        #[from]
         source: NegativeRange,
     },
     /// Cannot perform arithmetic for noncontiguous table commitments.
-    #[error("cannot perform table commitment arithmetic for noncontiguous table commitments")]
+    #[snafu(display(
+        "cannot perform table commitment arithmetic for noncontiguous table commitments"
+    ))]
     NonContiguous,
 }
 
 /// Errors that can occur when trying to create or extend a [`TableCommitment`] from a record batch.
 #[cfg(feature = "arrow")]
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum RecordBatchToColumnsError {
     /// Error converting from arrow array
-    #[error(transparent)]
+    #[snafu(transparent)]
     ArrowArrayToColumnConversionError {
         /// The underlying source error
-        #[from]
         source: ArrowArrayToColumnConversionError,
     },
-    #[error(transparent)]
+    #[snafu(transparent)]
     /// This error occurs when convering from a record batch name to an identifier fails. (Which may be impossible.)
     FieldParseFail {
         /// The underlying source error
-        #[from]
         source: ParseError,
     },
 }
 
 /// Errors that can occur when attempting to append a record batch to a [`TableCommitment`].
 #[cfg(feature = "arrow")]
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum AppendRecordBatchTableCommitmentError {
     /// During commitment operation, metadata indicates that operand tables cannot be the same.
-    #[error(transparent)]
+    #[snafu(transparent)]
     ColumnCommitmentsMismatch {
         /// The underlying source error
-        #[from]
         source: ColumnCommitmentsMismatch,
     },
     /// Error converting from arrow array
-    #[error(transparent)]
+    #[snafu(transparent)]
     ArrowBatchToColumnError {
         /// The underlying source error
-        #[from]
         source: RecordBatchToColumnsError,
     },
 }

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -1,11 +1,11 @@
 use super::Commitment;
 use crate::base::commitment::committable_column::CommittableColumn;
 use alloc::{vec, vec::Vec};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Cannot update commitment collections with different column counts
-#[derive(Error, Debug)]
-#[error("cannot update commitment collections with different column counts")]
+#[derive(Snafu, Debug)]
+#[snafu(display("cannot update commitment collections with different column counts"))]
 pub struct NumColumnsMismatch;
 
 /// Extension trait intended for collections of commitments.

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -20,20 +20,41 @@ pub enum ArrowArrayToColumnConversionError {
     #[error("arrow array must not contain nulls")]
     ArrayContainsNulls,
     /// This error occurs when trying to convert from an unsupported arrow type.
-    #[error("unsupported type: attempted conversion from ArrayRef of type {0} to OwnedColumn")]
-    UnsupportedType(DataType),
+    #[error(
+        "unsupported type: attempted conversion from ArrayRef of type {datatype} to OwnedColumn"
+    )]
+    UnsupportedType {
+        /// The unsupported datatype
+        datatype: DataType,
+    },
     /// Variant for decimal errors
     #[error(transparent)]
-    DecimalError(#[from] crate::base::math::decimal::DecimalError),
+    DecimalError {
+        /// The underlying source error
+        #[from]
+        source: crate::base::math::decimal::DecimalError,
+    },
     /// This error occurs when trying to convert from an i256 to a Scalar.
-    #[error("decimal conversion failed: {0}")]
-    DecimalConversionFailed(i256),
+    #[error("decimal conversion failed: {number}")]
+    DecimalConversionFailed {
+        /// The `i256` value for which conversion is attempted
+        number: i256,
+    },
     /// This error occurs when the specified range is out of the bounds of the array.
-    #[error("index out of bounds: the len is {0} but the index is {1}")]
-    IndexOutOfBounds(usize, usize),
+    #[error("index out of bounds: the len is {len} but the index is {index}")]
+    IndexOutOfBounds {
+        /// The actual length of the array
+        len: usize,
+        /// The out of bounds index requested
+        index: usize,
+    },
     /// Using TimeError to handle all time-related errors
     #[error(transparent)]
-    TimestampConversionError(#[from] PoSQLTimestampError),
+    TimestampConversionError {
+        /// The underlying source error
+        #[from]
+        source: PoSQLTimestampError,
+    },
 }
 
 /// This trait is used to provide utility functions to convert ArrayRefs into proof types (Column, Scalars, etc.)
@@ -114,7 +135,9 @@ impl ArrayRefExt for ArrayRef {
                             .iter()
                             .map(|v| {
                                 convert_i256_to_scalar(v).ok_or(
-                                    ArrowArrayToColumnConversionError::DecimalConversionFailed(*v),
+                                    ArrowArrayToColumnConversionError::DecimalConversionFailed {
+                                        number: *v,
+                                    },
                                 )
                             })
                             .collect()
@@ -151,9 +174,9 @@ impl ArrayRefExt for ArrayRef {
         };
 
         result.unwrap_or_else(|| {
-            Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                self.data_type().clone(),
-            ))
+            Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                datatype: self.data_type().clone(),
+            })
         })
     }
 
@@ -188,10 +211,10 @@ impl ArrayRefExt for ArrayRef {
 
         // Before performing any operations, check if the range is out of bounds
         if range.end > self.len() {
-            return Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(
-                self.len(),
-                range.end,
-            ));
+            return Err(ArrowArrayToColumnConversionError::IndexOutOfBounds {
+                len: self.len(),
+                index: range.end,
+            });
         }
         // Match supported types and attempt conversion
         match self.data_type() {
@@ -206,45 +229,45 @@ impl ArrayRefExt for ArrayRef {
                     let values = alloc.alloc_slice_fill_with(range.len(), |i| boolean_slice[i]);
                     Ok(Column::Boolean(values))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             DataType::Int16 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int16Array>() {
                     Ok(Column::SmallInt(&array.values()[range.start..range.end]))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             DataType::Int32 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int32Array>() {
                     Ok(Column::Int(&array.values()[range.start..range.end]))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             DataType::Int64 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int64Array>() {
                     Ok(Column::BigInt(&array.values()[range.start..range.end]))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             DataType::Decimal128(38, 0) => {
                 if let Some(array) = self.as_any().downcast_ref::<Decimal128Array>() {
                     Ok(Column::Int128(&array.values()[range.start..range.end]))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             DataType::Decimal256(precision, scale) if *precision <= 75 => {
@@ -253,7 +276,9 @@ impl ArrayRefExt for ArrayRef {
                     let scalars = alloc.alloc_slice_fill_default(i256_slice.len());
                     for (scalar, value) in scalars.iter_mut().zip(i256_slice) {
                         *scalar = convert_i256_to_scalar(value).ok_or(
-                            ArrowArrayToColumnConversionError::DecimalConversionFailed(*value),
+                            ArrowArrayToColumnConversionError::DecimalConversionFailed {
+                                number: *value,
+                            },
                         )?;
                     }
                     Ok(Column::Decimal75(
@@ -262,9 +287,9 @@ impl ArrayRefExt for ArrayRef {
                         scalars,
                     ))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
             // Handle all possible TimeStamp TimeUnit instances
@@ -277,9 +302,9 @@ impl ArrayRefExt for ArrayRef {
                             &array.values()[range.start..range.end],
                         ))
                     } else {
-                        Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                            self.data_type().clone(),
-                        ))
+                        Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                            datatype: self.data_type().clone(),
+                        })
                     }
                 }
                 ArrowTimeUnit::Millisecond => {
@@ -290,9 +315,9 @@ impl ArrayRefExt for ArrayRef {
                             &array.values()[range.start..range.end],
                         ))
                     } else {
-                        Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                            self.data_type().clone(),
-                        ))
+                        Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                            datatype: self.data_type().clone(),
+                        })
                     }
                 }
                 ArrowTimeUnit::Microsecond => {
@@ -303,9 +328,9 @@ impl ArrayRefExt for ArrayRef {
                             &array.values()[range.start..range.end],
                         ))
                     } else {
-                        Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                            self.data_type().clone(),
-                        ))
+                        Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                            datatype: self.data_type().clone(),
+                        })
                     }
                 }
                 ArrowTimeUnit::Nanosecond => {
@@ -316,9 +341,9 @@ impl ArrayRefExt for ArrayRef {
                             &array.values()[range.start..range.end],
                         ))
                     } else {
-                        Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                            self.data_type().clone(),
-                        ))
+                        Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                            datatype: self.data_type().clone(),
+                        })
                     }
                 }
             },
@@ -337,14 +362,14 @@ impl ArrayRefExt for ArrayRef {
 
                     Ok(Column::VarChar((vals, scals)))
                 } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                        self.data_type().clone(),
-                    ))
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
                 }
             }
-            data_type => Err(ArrowArrayToColumnConversionError::UnsupportedType(
-                data_type.clone(),
-            )),
+            data_type => Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                datatype: data_type.clone(),
+            }),
         }
     }
 }
@@ -420,7 +445,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(3..5), None);
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 5))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 5 })
         );
     }
 
@@ -447,7 +472,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(2..4), None);
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -570,7 +595,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(2..4), None);
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -617,7 +642,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(2..4), None);
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -689,7 +714,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -729,7 +754,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -769,7 +794,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 4))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
         );
     }
 
@@ -792,21 +817,21 @@ mod tests {
         let result1 = array1.to_column::<DoryScalar>(&alloc, &(2..3), None);
         assert_eq!(
             result1,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 3))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 })
         );
 
         let array2: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![1, -3]));
         let result2 = array2.to_column::<DoryScalar>(&alloc, &(2..3), None);
         assert_eq!(
             result2,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 3))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 })
         );
 
         let array3: ArrayRef = Arc::new(arrow::array::Int64Array::from(vec![1, -3]));
         let result3 = array3.to_column::<DoryScalar>(&alloc, &(2..3), None);
         assert_eq!(
             result3,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 3))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 })
         );
     }
 
@@ -818,21 +843,21 @@ mod tests {
         let result1 = array1.to_column::<Curve25519Scalar>(&alloc, &(5..5), None);
         assert_eq!(
             result1,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 5))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 5 })
         );
 
         let array2: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![1, -3]));
         let result2 = array2.to_column::<DoryScalar>(&alloc, &(5..5), None);
         assert_eq!(
             result2,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 5))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 5 })
         );
 
         let array3: ArrayRef = Arc::new(arrow::array::Int64Array::from(vec![1, -3]));
         let result3 = array3.to_column::<Curve25519Scalar>(&alloc, &(5..5), None);
         assert_eq!(
             result3,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 5))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 5 })
         );
     }
 
@@ -924,7 +949,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(0..3), None);
         assert_eq!(
             result,
-            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(2, 3))
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 })
         );
     }
 

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -10,38 +10,37 @@ use arrow::{
 };
 use bumpalo::Bump;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
+use snafu::Snafu;
 use std::ops::Range;
-use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Snafu, Debug, PartialEq)]
 /// Errors caused by conversions between Arrow and owned types.
 pub enum ArrowArrayToColumnConversionError {
     /// This error occurs when an array contains a non-zero number of null elements
-    #[error("arrow array must not contain nulls")]
+    #[snafu(display("arrow array must not contain nulls"))]
     ArrayContainsNulls,
     /// This error occurs when trying to convert from an unsupported arrow type.
-    #[error(
+    #[snafu(display(
         "unsupported type: attempted conversion from ArrayRef of type {datatype} to OwnedColumn"
-    )]
+    ))]
     UnsupportedType {
         /// The unsupported datatype
         datatype: DataType,
     },
     /// Variant for decimal errors
-    #[error(transparent)]
+    #[snafu(transparent)]
     DecimalError {
         /// The underlying source error
-        #[from]
         source: crate::base::math::decimal::DecimalError,
     },
     /// This error occurs when trying to convert from an i256 to a Scalar.
-    #[error("decimal conversion failed: {number}")]
+    #[snafu(display("decimal conversion failed: {number}"))]
     DecimalConversionFailed {
         /// The `i256` value for which conversion is attempted
         number: i256,
     },
     /// This error occurs when the specified range is out of the bounds of the array.
-    #[error("index out of bounds: the len is {len} but the index is {index}")]
+    #[snafu(display("index out of bounds: the len is {len} but the index is {index}"))]
     IndexOutOfBounds {
         /// The actual length of the array
         len: usize,
@@ -49,10 +48,9 @@ pub enum ArrowArrayToColumnConversionError {
         index: usize,
     },
     /// Using TimeError to handle all time-related errors
-    #[error(transparent)]
+    #[snafu(transparent)]
     TimestampConversionError {
         /// The underlying source error
-        #[from]
         source: PoSQLTimestampError,
     },
 }

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -50,16 +50,16 @@ pub fn try_add_subtract_column_types(
                 .max(right_precision_value - right_scale as i16)
             + 1_i16;
         let precision = u8::try_from(precision_value)
-            .map_err(|_| {
-                ColumnOperationError::DecimalConversionError(DecimalError::InvalidPrecision(
-                    precision_value.to_string(),
-                ))
+            .map_err(|_| ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision {
+                    error: precision_value.to_string(),
+                },
             })
             .and_then(|p| {
-                Precision::new(p).map_err(|_| {
-                    ColumnOperationError::DecimalConversionError(DecimalError::InvalidPrecision(
-                        p.to_string(),
-                    ))
+                Precision::new(p).map_err(|_| ColumnOperationError::DecimalConversionError {
+                    source: DecimalError::InvalidPrecision {
+                        error: p.to_string(),
+                    },
                 })
             })?;
         Ok(ColumnType::Decimal75(precision, scale))
@@ -91,17 +91,23 @@ pub fn try_multiply_column_types(
         let right_precision_value = rhs.precision_value().expect("Numeric types have precision");
         let precision_value = left_precision_value + right_precision_value + 1;
         let precision = Precision::new(precision_value).map_err(|_| {
-            ColumnOperationError::DecimalConversionError(DecimalError::InvalidPrecision(format!(
-                "Required precision {} is beyond what we can support",
-                precision_value
-            )))
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision {
+                    error: format!(
+                        "Required precision {} is beyond what we can support",
+                        precision_value
+                    ),
+                },
+            }
         })?;
         let left_scale = lhs.scale().expect("Numeric types have scale");
         let right_scale = rhs.scale().expect("Numeric types have scale");
         let scale = left_scale.checked_add(right_scale).ok_or(
-            ColumnOperationError::DecimalConversionError(DecimalError::InvalidScale(
-                left_scale as i16 + right_scale as i16,
-            )),
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale {
+                    scale: left_scale as i16 + right_scale as i16,
+                },
+            },
         )?;
         Ok(ColumnType::Decimal75(precision, scale))
     }
@@ -135,20 +141,21 @@ pub fn try_divide_column_types(
     let right_scale = rhs.scale().expect("Numeric types have scale") as i16;
     let raw_scale = (left_scale + right_precision_value + 1_i16).max(6_i16);
     let precision_value: i16 = left_precision_value - left_scale + right_scale + raw_scale;
-    let scale = i8::try_from(raw_scale).map_err(|_| {
-        ColumnOperationError::DecimalConversionError(DecimalError::InvalidScale(raw_scale))
-    })?;
+    let scale =
+        i8::try_from(raw_scale).map_err(|_| ColumnOperationError::DecimalConversionError {
+            source: DecimalError::InvalidScale { scale: raw_scale },
+        })?;
     let precision = u8::try_from(precision_value)
-        .map_err(|_| {
-            ColumnOperationError::DecimalConversionError(DecimalError::InvalidPrecision(
-                precision_value.to_string(),
-            ))
+        .map_err(|_| ColumnOperationError::DecimalConversionError {
+            source: DecimalError::InvalidPrecision {
+                error: precision_value.to_string(),
+            },
         })
         .and_then(|p| {
-            Precision::new(p).map_err(|_| {
-                ColumnOperationError::DecimalConversionError(DecimalError::InvalidPrecision(
-                    p.to_string(),
-                ))
+            Precision::new(p).map_err(|_| ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision {
+                    error: p.to_string(),
+                },
             })
         })?;
     Ok(ColumnType::Decimal75(precision, scale))
@@ -233,10 +240,9 @@ where
         .zip(rhs.iter())
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_add(r)
-                .ok_or(ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer addition {:?} + {:?}",
-                    l, r
-                )))
+                .ok_or(ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer addition {:?} + {:?}", l, r),
+                })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
 }
@@ -252,10 +258,9 @@ where
         .zip(rhs.iter())
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_sub(r)
-                .ok_or(ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer subtraction {:?} - {:?}",
-                    l, r
-                )))
+                .ok_or(ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
 }
@@ -271,10 +276,9 @@ where
         .zip(rhs.iter())
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_mul(r)
-                .ok_or(ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer multiplication {:?} * {:?}",
-                    l, r
-                )))
+                .ok_or(ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer multiplication {:?} * {:?}", l, r),
+                })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
 }
@@ -369,10 +373,9 @@ where
         .zip(numbers_of_larger_type.iter())
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_add(r).ok_or(
-                ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer addition {:?} + {:?}",
-                    l, r
-                )),
+                ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer addition {:?} + {:?}", l, r),
+                },
             )
         })
         .collect()
@@ -393,10 +396,9 @@ where
         .zip(rhs.iter())
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_sub(r).ok_or(
-                ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer subtraction {:?} - {:?}",
-                    l, r
-                )),
+                ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                },
             )
         })
         .collect()
@@ -417,10 +419,9 @@ where
         .zip(rhs.iter())
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             l.checked_sub(&Into::<LargerType>::into(*r)).ok_or(
-                ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer subtraction {:?} - {:?}",
-                    l, r
-                )),
+                ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                },
             )
         })
         .collect()
@@ -442,10 +443,9 @@ where
         .zip(numbers_of_larger_type.iter())
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_mul(r).ok_or(
-                ColumnOperationError::IntegerOverflow(format!(
-                    "Overflow in integer multiplication {:?} * {:?}",
-                    l, r
-                )),
+                ColumnOperationError::IntegerOverflow {
+                    error: format!("Overflow in integer multiplication {:?} * {:?}", l, r),
+                },
             )
         })
         .collect()
@@ -978,18 +978,18 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 4);
         assert!(matches!(
             try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 10);
         assert!(matches!(
             try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
     }
 
@@ -1076,18 +1076,18 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 1);
         assert!(matches!(
             try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         let lhs = ColumnType::Int128;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 12);
         assert!(matches!(
             try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
     }
 
@@ -1175,18 +1175,18 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(37).unwrap(), 4);
         assert!(matches!(
             try_multiply_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(65).unwrap(), 0);
         assert!(matches!(
             try_multiply_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         // Invalid scale
@@ -1194,18 +1194,18 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(5).unwrap(), -65_i8);
         assert!(matches!(
             try_multiply_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidScale(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale { .. }
+            })
         ));
 
         let lhs = ColumnType::Decimal75(Precision::new(5).unwrap(), 64_i8);
         let rhs = ColumnType::Decimal75(Precision::new(5).unwrap(), 64_i8);
         assert!(matches!(
             try_multiply_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidScale(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale { .. }
+            })
         ));
     }
 
@@ -1300,18 +1300,18 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(13).unwrap(), -14);
         assert!(matches!(
             try_divide_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(68).unwrap(), 67);
         assert!(matches!(
             try_divide_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidPrecision(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision { .. }
+            })
         ));
 
         // Invalid scale
@@ -1319,9 +1319,9 @@ mod test {
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 40_i8);
         assert!(matches!(
             try_divide_column_types(lhs, rhs),
-            Err(ColumnOperationError::DecimalConversionError(
-                DecimalError::InvalidScale(_)
-            ))
+            Err(ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale { .. }
+            })
         ));
     }
 
@@ -1740,7 +1740,7 @@ mod test {
         let rhs = [1_i16, 1];
         assert!(matches!(
             try_add_slices(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -1759,7 +1759,7 @@ mod test {
         let rhs = [i32::MIN, 1];
         assert!(matches!(
             try_add_slices_with_casting(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -1883,7 +1883,7 @@ mod test {
         let rhs = [1_i128, 1];
         assert!(matches!(
             try_subtract_slices(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -1902,7 +1902,7 @@ mod test {
         let rhs = [i32::MIN, 1];
         assert!(matches!(
             try_subtract_slices_left_upcast(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -1921,7 +1921,7 @@ mod test {
         let rhs = [1_i16, 1];
         assert!(matches!(
             try_subtract_slices_right_upcast(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -2045,7 +2045,7 @@ mod test {
         let rhs = [2, 2];
         assert!(matches!(
             try_multiply_slices(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 
@@ -2064,7 +2064,7 @@ mod test {
         let rhs = [i32::MAX, 2];
         assert!(matches!(
             try_multiply_slices_with_casting(&lhs, &rhs),
-            Err(ColumnOperationError::IntegerOverflow(_))
+            Err(ColumnOperationError::IntegerOverflow { .. })
         ));
     }
 

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -6,8 +6,13 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ColumnOperationError {
     /// Two columns do not have the same length
-    #[error("Columns have different lengths: {0} != {1}")]
-    DifferentColumnLength(usize, usize),
+    #[error("Columns have different lengths: {len_a} != {len_b}")]
+    DifferentColumnLength {
+        /// The length of the first column
+        len_a: usize,
+        /// The length of the second column
+        len_b: usize,
+    },
 
     /// Incorrect `ColumnType` in binary operations
     #[error("{operator:?}(lhs: {left_type:?}, rhs: {right_type:?}) is not supported")]
@@ -30,8 +35,11 @@ pub enum ColumnOperationError {
     },
 
     /// Overflow in integer operations
-    #[error("Overflow in integer operation: {0}")]
-    IntegerOverflow(String),
+    #[error("Overflow in integer operation: {error}")]
+    IntegerOverflow {
+        /// The underlying overflow error
+        error: String,
+    },
 
     /// Division by zero
     #[error("Division by zero")]
@@ -39,7 +47,11 @@ pub enum ColumnOperationError {
 
     /// Errors related to decimal operations
     #[error(transparent)]
-    DecimalConversionError(#[from] DecimalError),
+    DecimalConversionError {
+        /// The underlying source error
+        #[from]
+        source: DecimalError,
+    },
 }
 
 /// Result type for column operations

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,12 +1,12 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
 use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors from operations on columns.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum ColumnOperationError {
     /// Two columns do not have the same length
-    #[error("Columns have different lengths: {len_a} != {len_b}")]
+    #[snafu(display("Columns have different lengths: {len_a} != {len_b}"))]
     DifferentColumnLength {
         /// The length of the first column
         len_a: usize,
@@ -15,7 +15,7 @@ pub enum ColumnOperationError {
     },
 
     /// Incorrect `ColumnType` in binary operations
-    #[error("{operator:?}(lhs: {left_type:?}, rhs: {right_type:?}) is not supported")]
+    #[snafu(display("{operator:?}(lhs: {left_type:?}, rhs: {right_type:?}) is not supported"))]
     BinaryOperationInvalidColumnType {
         /// `BinaryOperator` that caused the error
         operator: BinaryOperator,
@@ -26,7 +26,7 @@ pub enum ColumnOperationError {
     },
 
     /// Incorrect `ColumnType` in unary operations
-    #[error("{operator:?}(operand: {operand_type:?}) is not supported")]
+    #[snafu(display("{operator:?}(operand: {operand_type:?}) is not supported"))]
     UnaryOperationInvalidColumnType {
         /// `UnaryOperator` that caused the error
         operator: UnaryOperator,
@@ -35,21 +35,20 @@ pub enum ColumnOperationError {
     },
 
     /// Overflow in integer operations
-    #[error("Overflow in integer operation: {error}")]
+    #[snafu(display("Overflow in integer operation: {error}"))]
     IntegerOverflow {
         /// The underlying overflow error
         error: String,
     },
 
     /// Division by zero
-    #[error("Division by zero")]
+    #[snafu(display("Division by zero"))]
     DivisionByZero,
 
     /// Errors related to decimal operations
-    #[error(transparent)]
+    #[snafu(transparent)]
     DecimalConversionError {
         /// The underlying source error
-        #[from]
         source: DecimalError,
     },
 }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -17,10 +17,9 @@ impl<S: Scalar> OwnedTable<S> {
             Expression::Literal(lit) => self.evaluate_literal(lit),
             Expression::Binary { op, left, right } => self.evaluate_binary_expr(*op, left, right),
             Expression::Unary { op, expr } => self.evaluate_unary_expr(*op, expr),
-            _ => Err(ExpressionEvaluationError::Unsupported(format!(
-                "Expression {:?} is not supported yet",
-                expr
-            ))),
+            _ => Err(ExpressionEvaluationError::Unsupported {
+                expression: format!("Expression {:?} is not supported yet", expr),
+            }),
         }
     }
 
@@ -31,9 +30,9 @@ impl<S: Scalar> OwnedTable<S> {
         Ok(self
             .inner_table()
             .get(identifier)
-            .ok_or(ExpressionEvaluationError::ColumnNotFound(
-                identifier.to_string(),
-            ))?
+            .ok_or(ExpressionEvaluationError::ColumnNotFound {
+                error: identifier.to_string(),
+            })?
             .clone())
     }
 

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -1,36 +1,31 @@
 use crate::base::{database::ColumnOperationError, math::decimal::DecimalError};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors from evaluation of `Expression`s.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum ExpressionEvaluationError {
     /// Column not found
-    #[error("Column not found: {error}")]
+    #[snafu(display("Column not found: {error}"))]
     ColumnNotFound {
         /// The underlying error
         error: String,
     },
     /// Error in column operation
-
-    #[error(transparent)]
+    #[snafu(transparent)]
     ColumnOperationError {
         /// The underlying source error
-        #[from]
         source: ColumnOperationError,
     },
     /// Expression not yet supported
-
-    #[error("Expression {expression} is not supported yet")]
+    #[snafu(display("Expression {expression} is not supported yet"))]
     Unsupported {
         /// The unsupported expression
         expression: String,
     },
     /// Error in decimal conversion
-
-    #[error(transparent)]
+    #[snafu(transparent)]
     DecimalConversionError {
         /// The underlying source error
-        #[from]
         source: DecimalError,
     },
 }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -5,17 +5,34 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ExpressionEvaluationError {
     /// Column not found
-    #[error("Column not found: {0}")]
-    ColumnNotFound(String),
+    #[error("Column not found: {error}")]
+    ColumnNotFound {
+        /// The underlying error
+        error: String,
+    },
     /// Error in column operation
+
     #[error(transparent)]
-    ColumnOperationError(#[from] ColumnOperationError),
+    ColumnOperationError {
+        /// The underlying source error
+        #[from]
+        source: ColumnOperationError,
+    },
     /// Expression not yet supported
-    #[error("Expression {0} is not supported yet")]
-    Unsupported(String),
+
+    #[error("Expression {expression} is not supported yet")]
+    Unsupported {
+        /// The unsupported expression
+        expression: String,
+    },
     /// Error in decimal conversion
+
     #[error(transparent)]
-    DecimalConversionError(#[from] DecimalError),
+    DecimalConversionError {
+        /// The underlying source error
+        #[from]
+        source: DecimalError,
+    },
 }
 
 /// Result type for expression evaluation

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -83,7 +83,7 @@ fn we_can_not_evaluate_a_nonexisting_column() {
     let expr = col("not_a_column");
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnNotFound(_))
+        Err(ExpressionEvaluationError::ColumnNotFound { .. })
     ));
 }
 
@@ -207,44 +207,44 @@ fn we_cannot_evaluate_expressions_if_column_operation_errors_out() {
     let expr = not(col("language"));
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnOperationError(
-            ColumnOperationError::UnaryOperationInvalidColumnType { .. }
-        ))
+        Err(ExpressionEvaluationError::ColumnOperationError {
+            source: ColumnOperationError::UnaryOperationInvalidColumnType { .. }
+        })
     ));
 
     // NOT doesn't work on bigint
     let expr = not(col("bigints"));
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnOperationError(
-            ColumnOperationError::UnaryOperationInvalidColumnType { .. }
-        ))
+        Err(ExpressionEvaluationError::ColumnOperationError {
+            source: ColumnOperationError::UnaryOperationInvalidColumnType { .. }
+        })
     ));
 
     // + doesn't work on varchar
     let expr = add(col("sarah"), col("bigints"));
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnOperationError(
-            ColumnOperationError::BinaryOperationInvalidColumnType { .. }
-        ))
+        Err(ExpressionEvaluationError::ColumnOperationError {
+            source: ColumnOperationError::BinaryOperationInvalidColumnType { .. }
+        })
     ));
 
     // i64::MIN - 1 overflows
     let expr = sub(col("bigints"), lit(1));
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnOperationError(
-            ColumnOperationError::IntegerOverflow(_)
-        ))
+        Err(ExpressionEvaluationError::ColumnOperationError {
+            source: ColumnOperationError::IntegerOverflow { .. }
+        })
     ));
 
     // We can't divide by zero
     let expr = div(col("bigints"), lit(0));
     assert!(matches!(
         table.evaluate(&expr),
-        Err(ExpressionEvaluationError::ColumnOperationError(
-            ColumnOperationError::DivisionByZero
-        ))
+        Err(ExpressionEvaluationError::ColumnOperationError {
+            source: ColumnOperationError::DivisionByZero
+        })
     ));
 }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -8,7 +8,7 @@ use bumpalo::Bump;
 use core::cmp::Ordering;
 use itertools::Itertools;
 use rayon::prelude::ParallelSliceMut;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// The output of the `aggregate_columns` function.
 #[derive(Debug)]
@@ -27,9 +27,9 @@ pub struct AggregatedColumns<'a, S: Scalar> {
     /// The number of rows in each group.
     pub count_column: &'a [i64],
 }
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum AggregateColumnsError {
-    #[error("Column length mismatch")]
+    #[snafu(display("Column length mismatch"))]
     ColumnLengthMismatch,
 }
 

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -36,50 +36,43 @@ use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
     Identifier, ParseError,
 };
+use snafu::Snafu;
 use std::sync::Arc;
-use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 #[non_exhaustive]
 /// Errors cause by conversions between Arrow and owned types.
 pub enum OwnedArrowConversionError {
     /// This error occurs when trying to convert from an unsupported arrow type.
-
-    #[error(
+    #[snafu(display(
         "unsupported type: attempted conversion from ArrayRef of type {datatype} to OwnedColumn"
-    )]
+    ))]
     UnsupportedType {
         /// The unsupported datatype
         datatype: DataType,
     },
     /// This error occurs when trying to convert from a record batch with duplicate identifiers (e.g. `"a"` and `"A"`).
-    #[error("conversion resulted in duplicate identifiers")]
+    #[snafu(display("conversion resulted in duplicate identifiers"))]
     DuplicateIdentifiers,
-
-    #[error(transparent)]
     /// This error occurs when convering from a record batch name to an identifier fails. (Which may my impossible.)
+    #[snafu(transparent)]
     FieldParseFail {
         /// The underlying source error
-        #[from]
         source: ParseError,
     },
-
-    #[error(transparent)]
     /// This error occurs when creating an owned table fails, which should only occur when there are zero columns.
+    #[snafu(transparent)]
     InvalidTable {
         /// The underlying source error
-        #[from]
         source: OwnedTableError,
     },
     /// This error occurs when trying to convert from an Arrow array with nulls.
-    #[error("null values are not supported in OwnedColumn yet")]
+    #[snafu(display("null values are not supported in OwnedColumn yet"))]
     NullNotSupportedYet,
     /// Using TimeError to handle all time-related errors
-
-    #[error(transparent)]
+    #[snafu(transparent)]
     TimestampConversionError {
         /// The underlying source error
-        #[from]
         source: PoSQLTimestampError,
     },
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -76,7 +76,7 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
     let array_ref: ArrayRef = Arc::new(Float32Array::from(vec![0.0]));
     assert!(matches!(
         OwnedColumn::<Curve25519Scalar>::try_from(array_ref),
-        Err(OwnedArrowConversionError::UnsupportedType(_))
+        Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -137,10 +137,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<bool, _> { TryInto::<bool>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
             ColumnType::SmallInt => Ok(OwnedColumn::SmallInt(
@@ -148,10 +146,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<i16, _> { TryInto::<i16>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
             ColumnType::Int => Ok(OwnedColumn::Int(
@@ -159,10 +155,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<i32, _> { TryInto::<i32>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
             ColumnType::BigInt => Ok(OwnedColumn::BigInt(
@@ -170,10 +164,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
             ColumnType::Int128 => Ok(OwnedColumn::Int128(
@@ -181,10 +173,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<i128, _> { TryInto::<i128>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
             ColumnType::Scalar => Ok(OwnedColumn::Scalar(scalars.to_vec())),
@@ -196,10 +186,8 @@ impl<S: Scalar> OwnedColumn<S> {
                     .iter()
                     .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|_| {
-                        OwnedColumnError::ScalarConversionError(
-                            "Overflow in scalar conversions".to_string(),
-                        )
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
                     })?;
                 Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
             }
@@ -220,9 +208,9 @@ impl<S: Scalar> OwnedColumn<S> {
             .iter()
             .copied()
             .collect::<Option<Vec<_>>>()
-            .ok_or(OwnedColumnError::Unsupported(
-                "NULL is not supported yet".to_string(),
-            ))?;
+            .ok_or(OwnedColumnError::Unsupported {
+                error: "NULL is not supported yet".to_string(),
+            })?;
         Self::try_from_scalars(&scalars, column_type)
     }
 
@@ -523,7 +511,7 @@ mod test {
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
         assert!(matches!(
             res,
-            Err(OwnedColumnError::ScalarConversionError(_))
+            Err(OwnedColumnError::ScalarConversionError { .. })
         ));
 
         // Boolean
@@ -535,7 +523,7 @@ mod test {
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
         assert!(matches!(
             res,
-            Err(OwnedColumnError::ScalarConversionError(_))
+            Err(OwnedColumnError::ScalarConversionError { .. })
         ));
     }
 
@@ -607,7 +595,7 @@ mod test {
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
         assert!(matches!(
             res,
-            Err(OwnedColumnError::ScalarConversionError(_))
+            Err(OwnedColumnError::ScalarConversionError { .. })
         ));
 
         // Boolean
@@ -625,7 +613,7 @@ mod test {
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
         assert!(matches!(
             res,
-            Err(OwnedColumnError::ScalarConversionError(_))
+            Err(OwnedColumnError::ScalarConversionError { .. })
         ));
     }
 
@@ -638,7 +626,7 @@ mod test {
             .collect::<Vec<_>>();
         let column_type = ColumnType::Int128;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
-        assert!(matches!(res, Err(OwnedColumnError::Unsupported(_))));
+        assert!(matches!(res, Err(OwnedColumnError::Unsupported { .. })));
 
         // Boolean
         let option_scalars = [Some(true), Some(false), None, Some(false), Some(true)]
@@ -647,6 +635,6 @@ mod test {
             .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
-        assert!(matches!(res, Err(OwnedColumnError::Unsupported(_))));
+        assert!(matches!(res, Err(OwnedColumnError::Unsupported { .. })));
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -14,11 +14,19 @@ pub enum OwnedColumnError {
         to_type: ColumnType,
     },
     /// Error in converting scalars to a given column type.
-    #[error("Error in converting scalars to a given column type: {0}")]
-    ScalarConversionError(String),
+
+    #[error("Error in converting scalars to a given column type: {error}")]
+    ScalarConversionError {
+        /// The underlying error
+        error: String,
+    },
     /// Unsupported operation.
-    #[error("Unsupported operation: {0}")]
-    Unsupported(String),
+
+    #[error("Unsupported operation: {error}")]
+    Unsupported {
+        /// The underlying error
+        error: String,
+    },
 }
 
 /// Result type for operations related to `OwnedColumn`s.

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -1,28 +1,26 @@
 use crate::base::database::ColumnType;
 use alloc::string::String;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors from operations related to `OwnedColumn`s.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum OwnedColumnError {
     /// Can not perform type casting.
-    #[error("Can not perform type casting from {from_type:?} to {to_type:?}")]
+    #[snafu(display("Can not perform type casting from {from_type:?} to {to_type:?}"))]
     TypeCastError {
         /// The type from which we are trying to cast.
         from_type: ColumnType,
         /// The type to which we are trying to cast.
         to_type: ColumnType,
     },
-    /// Error in converting scalars to a given column type.
-
-    #[error("Error in converting scalars to a given column type: {error}")]
+    /// Error in converting scalars to a given column type.   
+    #[snafu(display("Error in converting scalars to a given column type: {error}"))]
     ScalarConversionError {
         /// The underlying error
         error: String,
     },
     /// Unsupported operation.
-
-    #[error("Unsupported operation: {error}")]
+    #[snafu(display("Unsupported operation: {error}"))]
     Unsupported {
         /// The underlying error
         error: String,

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -21,10 +21,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise AND for two columns
     pub fn element_wise_and(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_and(lhs, rhs))),
@@ -39,10 +39,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise OR for two columns
     pub fn element_wise_or(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_or(lhs, rhs))),
@@ -57,10 +57,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise equality check for two columns
     pub fn element_wise_eq(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (self, rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
@@ -192,10 +192,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise <= check for two columns
     pub fn element_wise_le(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (self, rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
@@ -326,10 +326,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise >= check for two columns
     pub fn element_wise_ge(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (self, rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
@@ -463,10 +463,10 @@ impl<S: Scalar> Add for OwnedColumn<S> {
 
     fn add(self, rhs: Self) -> Self::Output {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (&self, &rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
@@ -606,10 +606,10 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
 
     fn sub(self, rhs: Self) -> Self::Output {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (&self, &rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
@@ -753,10 +753,10 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
 
     fn mul(self, rhs: Self) -> Self::Output {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (&self, &rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
@@ -900,10 +900,10 @@ impl<S: Scalar> Div for OwnedColumn<S> {
 
     fn div(self, rhs: Self) -> Self::Output {
         if self.len() != rhs.len() {
-            return Err(ColumnOperationError::DifferentColumnLength(
-                self.len(),
-                rhs.len(),
-            ));
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
         }
         match (&self, &rhs) {
             (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
@@ -1055,25 +1055,25 @@ mod test {
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs.element_wise_eq(&rhs);
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs.element_wise_le(&rhs);
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs.element_wise_ge(&rhs);
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
@@ -1081,25 +1081,25 @@ mod test {
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs.clone() - rhs.clone();
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs.clone() * rhs.clone();
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
         let result = lhs / rhs;
         assert!(matches!(
             result,
-            Err(ColumnOperationError::DifferentColumnLength(_, _))
+            Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
     }
 

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -2,13 +2,13 @@ use super::OwnedColumn;
 use crate::base::scalar::Scalar;
 use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// An error that occurs when working with tables.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum OwnedTableError {
     /// The columns have different lengths.
-    #[error("Columns have different lengths")]
+    #[snafu(display("Columns have different lengths"))]
     ColumnLengthMismatch,
 }
 /// A table of data, with schema included. This is simply a map from `Identifier` to `OwnedColumn`,

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -11,32 +11,48 @@ use thiserror::Error;
 /// Errors related to decimal operations.
 #[derive(Error, Debug, Eq, PartialEq)]
 pub enum DecimalError {
-    #[error("Invalid decimal format or value: {0}")]
+    #[error("Invalid decimal format or value: {error}")]
     /// Error when a decimal format or value is incorrect,
     /// the string isn't even a decimal e.g. "notastring",
     /// "-21.233.122" etc aka InvalidDecimal
-    InvalidDecimal(String),
+    InvalidDecimal {
+        /// The underlying error
+        error: String,
+    },
 
-    #[error("Decimal precision is not valid: {0}")]
+    #[error("Decimal precision is not valid: {error}")]
     /// Decimal precision exceeds the allowed limit,
     /// e.g. precision above 75/76/whatever set by Scalar
     /// or non-positive aka InvalidPrecision
-    InvalidPrecision(String),
+    InvalidPrecision {
+        /// The underlying error
+        error: String,
+    },
 
-    #[error("Decimal scale is not valid: {0}")]
+    #[error("Decimal scale is not valid: {scale}")]
     /// Decimal scale is not valid. Here we use i16 in order to include
     /// invalid scale values
-    InvalidScale(i16),
+    InvalidScale {
+        /// The invalid scale value
+        scale: i16,
+    },
 
-    #[error("Unsupported operation: cannot round decimal: {0}")]
+    #[error("Unsupported operation: cannot round decimal: {error}")]
     /// This error occurs when attempting to scale a
     /// decimal in such a way that a loss of precision occurs.
-    RoundingError(String),
+    RoundingError {
+        /// The underlying error
+        error: String,
+    },
 
     /// Errors that may occur when parsing an intermediate decimal
     /// into a posql decimal
     #[error(transparent)]
-    IntermediateDecimalConversionError(#[from] IntermediateDecimalError),
+    IntermediateDecimalConversionError {
+        /// The underlying source error
+        #[from]
+        source: IntermediateDecimalError,
+    },
 }
 
 /// Result type for decimal operations.
@@ -58,10 +74,12 @@ impl Precision {
     /// Constructor for creating a Precision instance
     pub fn new(value: u8) -> Result<Self, DecimalError> {
         if value > MAX_SUPPORTED_PRECISION || value == 0 {
-            Err(DecimalError::InvalidPrecision(format!(
-                "Failed to parse precision. Value of {} exceeds max supported precision of {}",
-                value, MAX_SUPPORTED_PRECISION
-            )))
+            Err(DecimalError::InvalidPrecision {
+                error: format!(
+                    "Failed to parse precision. Value of {} exceeds max supported precision of {}",
+                    value, MAX_SUPPORTED_PRECISION
+                ),
+            })
         } else {
             Ok(Precision(value))
         }
@@ -116,9 +134,9 @@ impl<S: Scalar> Decimal<S> {
     ) -> DecimalResult<Decimal<S>> {
         let scale_factor = new_scale - self.scale;
         if scale_factor < 0 || new_precision.value() < self.precision.value() + scale_factor as u8 {
-            return Err(DecimalError::RoundingError(
-                "Scale factor must be non-negative".to_string(),
-            ));
+            return Err(DecimalError::RoundingError {
+                error: "Scale factor must be non-negative".to_string(),
+            });
         }
         let scaled_value = scale_scalar(self.value, scale_factor)?;
         Ok(Decimal::new(scaled_value, new_precision, new_scale))
@@ -129,14 +147,14 @@ impl<S: Scalar> Decimal<S> {
         const MINIMAL_PRECISION: u8 = 19;
         let raw_precision = precision.value();
         if raw_precision < MINIMAL_PRECISION {
-            return Err(DecimalError::RoundingError(
-                "Precision must be at least 19".to_string(),
-            ));
+            return Err(DecimalError::RoundingError {
+                error: "Precision must be at least 19".to_string(),
+            });
         }
         if scale < 0 || raw_precision < MINIMAL_PRECISION + scale as u8 {
-            return Err(DecimalError::RoundingError(
-                "Can not scale down a decimal".to_string(),
-            ));
+            return Err(DecimalError::RoundingError {
+                error: "Can not scale down a decimal".to_string(),
+            });
         }
         let scaled_value = scale_scalar(S::from(&value), scale)?;
         Ok(Decimal::new(scaled_value, precision, scale))
@@ -147,14 +165,14 @@ impl<S: Scalar> Decimal<S> {
         const MINIMAL_PRECISION: u8 = 39;
         let raw_precision = precision.value();
         if raw_precision < MINIMAL_PRECISION {
-            return Err(DecimalError::RoundingError(
-                "Precision must be at least 19".to_string(),
-            ));
+            return Err(DecimalError::RoundingError {
+                error: "Precision must be at least 19".to_string(),
+            });
         }
         if scale < 0 || raw_precision < MINIMAL_PRECISION + scale as u8 {
-            return Err(DecimalError::RoundingError(
-                "Can not scale down a decimal".to_string(),
-            ));
+            return Err(DecimalError::RoundingError {
+                error: "Can not scale down a decimal".to_string(),
+            });
         }
         let scaled_value = scale_scalar(S::from(&value), scale)?;
         Ok(Decimal::new(scaled_value, precision, scale))
@@ -185,7 +203,9 @@ pub(crate) fn try_into_to_scalar<S: Scalar>(
 ) -> DecimalResult<S> {
     d.try_into_bigint_with_precision_and_scale(target_precision.value(), target_scale)?
         .try_into()
-        .map_err(|e: ScalarConversionError| DecimalError::InvalidDecimal(e.to_string()))
+        .map_err(|e: ScalarConversionError| DecimalError::InvalidDecimal {
+            error: e.to_string(),
+        })
 }
 
 /// Scale scalar by the given scale factor. Negative scaling is not allowed.
@@ -193,9 +213,9 @@ pub(crate) fn try_into_to_scalar<S: Scalar>(
 pub(crate) fn scale_scalar<S: Scalar>(s: S, scale: i8) -> DecimalResult<S> {
     match scale {
         0 => Ok(s),
-        _ if scale < 0 => Err(DecimalError::RoundingError(
-            "Scale factor must be non-negative".to_string(),
-        )),
+        _ if scale < 0 => Err(DecimalError::RoundingError {
+            error: "Scale factor must be non-negative".to_string(),
+        }),
         _ => {
             let ten = S::from(10);
             let mut res = s;

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -6,12 +6,12 @@ use alloc::{
 };
 use proof_of_sql_parser::intermediate_decimal::{IntermediateDecimal, IntermediateDecimalError};
 use serde::{Deserialize, Deserializer, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors related to decimal operations.
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Snafu, Debug, Eq, PartialEq)]
 pub enum DecimalError {
-    #[error("Invalid decimal format or value: {error}")]
+    #[snafu(display("Invalid decimal format or value: {error}"))]
     /// Error when a decimal format or value is incorrect,
     /// the string isn't even a decimal e.g. "notastring",
     /// "-21.233.122" etc aka InvalidDecimal
@@ -20,7 +20,7 @@ pub enum DecimalError {
         error: String,
     },
 
-    #[error("Decimal precision is not valid: {error}")]
+    #[snafu(display("Decimal precision is not valid: {error}"))]
     /// Decimal precision exceeds the allowed limit,
     /// e.g. precision above 75/76/whatever set by Scalar
     /// or non-positive aka InvalidPrecision
@@ -29,7 +29,7 @@ pub enum DecimalError {
         error: String,
     },
 
-    #[error("Decimal scale is not valid: {scale}")]
+    #[snafu(display("Decimal scale is not valid: {scale}"))]
     /// Decimal scale is not valid. Here we use i16 in order to include
     /// invalid scale values
     InvalidScale {
@@ -37,7 +37,7 @@ pub enum DecimalError {
         scale: i16,
     },
 
-    #[error("Unsupported operation: cannot round decimal: {error}")]
+    #[snafu(display("Unsupported operation: cannot round decimal: {error}"))]
     /// This error occurs when attempting to scale a
     /// decimal in such a way that a loss of precision occurs.
     RoundingError {
@@ -47,10 +47,9 @@ pub enum DecimalError {
 
     /// Errors that may occur when parsing an intermediate decimal
     /// into a posql decimal
-    #[error(transparent)]
+    #[snafu(transparent)]
     IntermediateDecimalConversionError {
         /// The underlying source error
-        #[from]
         source: IntermediateDecimalError,
     },
 }

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -1,14 +1,14 @@
 use alloc::{format, string::String, vec::Vec};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// An error that occurs when working with permutations
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum PermutationError {
     /// The permutation is invalid
-    #[error("Permutation is invalid {error}")]
+    #[snafu(display("Permutation is invalid {error}"))]
     InvalidPermutation { error: String },
     /// Application of a permutation to a slice with an incorrect length
-    #[error("Application of a permutation to a slice with a different length {permutation_size} != {slice_length}")]
+    #[snafu(display("Application of a permutation to a slice with a different length {permutation_size} != {slice_length}"))]
     PermutationSizeMismatch {
         permutation_size: usize,
         slice_length: usize,

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PermutationError {
     /// The permutation is invalid
-    #[error("Permutation is invalid {0}")]
-    InvalidPermutation(String),
+    #[error("Permutation is invalid {error}")]
+    InvalidPermutation { error: String },
     /// Application of a permutation to a slice with an incorrect length
     #[error("Application of a permutation to a slice with a different length {permutation_size} != {slice_length}")]
     PermutationSizeMismatch {
@@ -39,17 +39,21 @@ impl Permutation {
         elements.sort_unstable();
         elements.dedup();
         if elements.len() < length {
-            Err(PermutationError::InvalidPermutation(format!(
-                "Permutation can not have duplicate elements: {:?}",
-                permutation
-            )))
+            Err(PermutationError::InvalidPermutation {
+                error: format!(
+                    "Permutation can not have duplicate elements: {:?}",
+                    permutation
+                ),
+            })
         }
         // Check that no element is out of bounds
         else if permutation.iter().any(|&i| i >= length) {
-            Err(PermutationError::InvalidPermutation(format!(
-                "Permutation can not have elements out of bounds: {:?}",
-                permutation
-            )))
+            Err(PermutationError::InvalidPermutation {
+                error: format!(
+                    "Permutation can not have elements out of bounds: {:?}",
+                    permutation
+                ),
+            })
         } else {
             Ok(Self { permutation })
         }
@@ -95,11 +99,11 @@ mod test {
     fn test_invalid_permutation() {
         assert!(matches!(
             Permutation::try_new(vec![1, 0, 0]),
-            Err(PermutationError::InvalidPermutation(_))
+            Err(PermutationError::InvalidPermutation { .. })
         ));
         assert!(matches!(
             Permutation::try_new(vec![1, 0, 3]),
-            Err(PermutationError::InvalidPermutation(_))
+            Err(PermutationError::InvalidPermutation { .. })
         ));
     }
 

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 /// These errors occur when a proof failed to verify.
 pub enum ProofError {
-    #[error("Verification error: {0}")]
+    #[error("Verification error: {error}")]
     /// This error occurs when a proof failed to verify.
-    VerificationError(&'static str),
+    VerificationError { error: &'static str },
 }

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -1,9 +1,9 @@
-use thiserror::Error;
+use snafu::Snafu;
 
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 /// These errors occur when a proof failed to verify.
 pub enum ProofError {
-    #[error("Verification error: {error}")]
+    #[snafu(display("Verification error: {error}"))]
     /// This error occurs when a proof failed to verify.
     VerificationError { error: &'static str },
 }

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -1,10 +1,10 @@
 use alloc::string::String;
-use thiserror::Error;
+use snafu::Snafu;
 
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 /// These errors occur when a scalar conversion fails.
 pub enum ScalarConversionError {
-    #[error("Overflow error: {error}")]
+    #[snafu(display("Overflow error: {error}"))]
     /// This error occurs when a scalar is too large to be converted.
     Overflow {
         /// The underlying error

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -4,7 +4,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 /// These errors occur when a scalar conversion fails.
 pub enum ScalarConversionError {
-    #[error("Overflow error: {0}")]
+    #[error("Overflow error: {error}")]
     /// This error occurs when a scalar is too large to be converted.
-    Overflow(String),
+    Overflow {
+        /// The underlying error
+        error: String,
+    },
 }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -165,11 +165,11 @@ impl<T: MontConfig<4>> TryFrom<BigInt> for MontScalar<T> {
 
         // Check if the number of digits exceeds the maximum precision allowed
         if digits.len() > MAX_SUPPORTED_PRECISION.into() {
-            return Err(ScalarConversionError::Overflow(format!(
+            return Err(ScalarConversionError::Overflow{ error: format!(
                 "Attempted to parse a number with {} digits, which exceeds the max supported precision of {}",
                 digits.len(),
                 MAX_SUPPORTED_PRECISION
-            )));
+            )});
         }
 
         // Continue with the previous logic
@@ -380,19 +380,17 @@ where
             (1, value.into())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i8",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i8", value),
+            });
         }
         let val: i128 = sign * abs[0] as i128;
         match val {
             0 => Ok(false),
             1 => Ok(true),
-            _ => Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in a bool",
-                value
-            ))),
+            _ => Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in a bool", value),
+            }),
         }
     }
 }
@@ -410,14 +408,13 @@ where
             (1, value.into())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i8",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i8", value),
+            });
         }
         let val: i128 = sign * abs[0] as i128;
-        val.try_into().map_err(|_| {
-            ScalarConversionError::Overflow(format!("{} is too large to fit in an i8", value))
+        val.try_into().map_err(|_| ScalarConversionError::Overflow {
+            error: format!("{} is too large to fit in an i8", value),
         })
     }
 }
@@ -435,14 +432,13 @@ where
             (1, value.into())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i16",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i16", value),
+            });
         }
         let val: i128 = sign * abs[0] as i128;
-        val.try_into().map_err(|_| {
-            ScalarConversionError::Overflow(format!("{} is too large to fit in an i16", value))
+        val.try_into().map_err(|_| ScalarConversionError::Overflow {
+            error: format!("{} is too large to fit in an i16", value),
         })
     }
 }
@@ -460,14 +456,13 @@ where
             (1, value.into())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i32",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i32", value),
+            });
         }
         let val: i128 = sign * abs[0] as i128;
-        val.try_into().map_err(|_| {
-            ScalarConversionError::Overflow(format!("{} is too large to fit in an i32", value))
+        val.try_into().map_err(|_| ScalarConversionError::Overflow {
+            error: format!("{} is too large to fit in an i32", value),
         })
     }
 }
@@ -485,14 +480,13 @@ where
             (1, value.into())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i64",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i64", value),
+            });
         }
         let val: i128 = sign * abs[0] as i128;
-        val.try_into().map_err(|_| {
-            ScalarConversionError::Overflow(format!("{} is too large to fit in an i64", value))
+        val.try_into().map_err(|_| ScalarConversionError::Overflow {
+            error: format!("{} is too large to fit in an i64", value),
         })
     }
 }
@@ -510,20 +504,18 @@ where
             (1, value.into())
         };
         if abs[2] != 0 || abs[3] != 0 {
-            return Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i128",
-                value
-            )));
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i128", value),
+            });
         }
         let val: u128 = (abs[1] as u128) << 64 | (abs[0] as u128);
         match (sign, val) {
             (1, v) if v <= i128::MAX as u128 => Ok(v as i128),
             (-1, v) if v <= i128::MAX as u128 => Ok(-(v as i128)),
             (-1, v) if v == i128::MAX as u128 + 1 => Ok(i128::MIN),
-            _ => Err(ScalarConversionError::Overflow(format!(
-                "{} is too large to fit in an i128",
-                value
-            ))),
+            _ => Err(ScalarConversionError::Overflow {
+                error: format!("{} is too large to fit in an i128", value),
+            }),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -114,15 +114,15 @@ fn test_curve25519_scalar_to_bool() {
 fn test_curve25519_scalar_to_bool_overflow() {
     matches!(
         bool::try_from(Curve25519Scalar::from(2)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         bool::try_from(Curve25519Scalar::from(-1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         bool::try_from(Curve25519Scalar::from(-2)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -145,11 +145,11 @@ fn test_curve25519_scalar_to_i8() {
 fn test_curve25519_scalar_to_i8_overflow() {
     matches!(
         i8::try_from(Curve25519Scalar::from(i8::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i8::try_from(Curve25519Scalar::from(i8::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -172,11 +172,11 @@ fn test_curve25519_scalar_to_i16() {
 fn test_curve25519_scalar_to_i16_overflow() {
     matches!(
         i16::try_from(Curve25519Scalar::from(i16::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i16::try_from(Curve25519Scalar::from(i16::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -199,11 +199,11 @@ fn test_curve25519_scalar_to_i32() {
 fn test_curve25519_scalar_to_i32_overflow() {
     matches!(
         i32::try_from(Curve25519Scalar::from(i32::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i32::try_from(Curve25519Scalar::from(i32::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -226,11 +226,11 @@ fn test_curve25519_scalar_to_i64() {
 fn test_curve25519_scalar_to_i64_overflow() {
     matches!(
         i64::try_from(Curve25519Scalar::from(i64::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i64::try_from(Curve25519Scalar::from(i64::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -253,11 +253,11 @@ fn test_curve25519_scalar_to_i128() {
 fn test_curve25519_scalar_to_i128_overflow() {
     matches!(
         i128::try_from(Curve25519Scalar::from(i128::MAX) + Curve25519Scalar::ONE),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i128::try_from(Curve25519Scalar::from(i128::MIN) - Curve25519Scalar::ONE),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
@@ -7,22 +7,22 @@ use super::{
 };
 use crate::base::commitment::CommitmentEvaluationProof;
 use merlin::Transcript;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// The `CommitmentEvaluationProof` for the Dory PCS.
 pub type DoryEvaluationProof = DoryMessages;
 
 /// The error type for the Dory PCS.
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 pub enum DoryError {
     /// This error occurs when the generators offset is invalid.
-    #[error("invalid generators offset: {offset}")]
+    #[snafu(display("invalid generators offset: {offset}"))]
     InvalidGeneratorsOffset { offset: u64 },
     /// This error occurs when the proof fails to verify.
-    #[error("verification error")]
+    #[snafu(display("verification error"))]
     VerificationError,
     /// This error occurs when the setup is too small.
-    #[error("setup is too small: the setup is {actual}, but the proof requires a setup of size {required}")]
+    #[snafu(display("setup is too small: the setup is {actual}, but the proof requires a setup of size {required}"))]
     SmallSetup { actual: usize, required: usize },
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -13,15 +13,15 @@ fn test_dory_scalar_to_bool() {
 fn test_dory_scalar_to_bool_overflow() {
     matches!(
         bool::try_from(DoryScalar::from(2)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         bool::try_from(DoryScalar::from(-1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         bool::try_from(DoryScalar::from(-2)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -38,11 +38,11 @@ fn test_dory_scalar_to_i8() {
 fn test_dory_scalar_to_i8_overflow() {
     matches!(
         i8::try_from(DoryScalar::from(i8::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i8::try_from(DoryScalar::from(i8::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -59,11 +59,11 @@ fn test_dory_scalar_to_i16() {
 fn test_dory_scalar_to_i16_overflow() {
     matches!(
         i16::try_from(DoryScalar::from(i16::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i16::try_from(DoryScalar::from(i16::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -80,11 +80,11 @@ fn test_dory_scalar_to_i32() {
 fn test_dory_scalar_to_i32_overflow() {
     matches!(
         i32::try_from(DoryScalar::from(i32::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i32::try_from(DoryScalar::from(i32::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -101,11 +101,11 @@ fn test_dory_scalar_to_i64() {
 fn test_dory_scalar_to_i64_overflow() {
     matches!(
         i64::try_from(DoryScalar::from(i64::MAX as i128 + 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i64::try_from(DoryScalar::from(i64::MIN as i128 - 1)),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 
@@ -128,11 +128,11 @@ fn test_dory_scalar_to_i128() {
 fn test_dory_scalar_to_i128_overflow() {
     matches!(
         i128::try_from(DoryScalar::from(i128::MAX) + DoryScalar::ONE),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
     matches!(
         i128::try_from(DoryScalar::from(i128::MIN) - DoryScalar::ONE),
-        Err(ScalarConversionError::Overflow(_))
+        Err(ScalarConversionError::Overflow { .. })
     );
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
@@ -18,14 +18,14 @@ pub struct DynamicDoryEvaluationProof(pub(super) DoryMessages);
 #[derive(Error, Debug)]
 pub enum DoryError {
     /// This error occurs when the generators offset is invalid.
-    #[error("invalid generators offset: {0}")]
-    InvalidGeneratorsOffset(u64),
+    #[error("invalid generators offset: {offset}")]
+    InvalidGeneratorsOffset { offset: u64 },
     /// This error occurs when the proof fails to verify.
     #[error("verification error")]
     VerificationError,
     /// This error occurs when the setup is too small.
-    #[error("setup is too small: the setup is {0}, but the proof requires a setup of size {1}")]
-    SmallSetup(usize, usize),
+    #[error("setup is too small: the setup is {actual}, but the proof requires a setup of size {required}")]
+    SmallSetup { actual: usize, required: usize },
 }
 
 impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
@@ -86,13 +86,18 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         );
         // Dory PCS Logic
         if generators_offset != 0 {
-            return Err(DoryError::InvalidGeneratorsOffset(generators_offset));
+            return Err(DoryError::InvalidGeneratorsOffset {
+                offset: generators_offset,
+            });
         }
         let b_point: &[F] = bytemuck::TransparentWrapper::peel_slice(b_point);
         let mut messages = self.0.clone();
         let nu = compute_dynamic_nu(b_point.len());
         if nu > setup.max_nu {
-            return Err(DoryError::SmallSetup(setup.max_nu, nu));
+            return Err(DoryError::SmallSetup {
+                actual: setup.max_nu,
+                required: nu,
+            });
         }
         let state = build_dynamic_vmv_verifier_state(product.0, b_point, a_commit, nu);
         let extended_state = eval_vmv_re_verify(&mut messages, transcript, state, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
@@ -8,23 +8,23 @@ use super::{
 use crate::base::commitment::CommitmentEvaluationProof;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// The `CommitmentEvaluationProof` for the Dory PCS.
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct DynamicDoryEvaluationProof(pub(super) DoryMessages);
 
 /// The error type for the Dory PCS.
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 pub enum DoryError {
     /// This error occurs when the generators offset is invalid.
-    #[error("invalid generators offset: {offset}")]
+    #[snafu(display("invalid generators offset: {offset}"))]
     InvalidGeneratorsOffset { offset: u64 },
     /// This error occurs when the proof fails to verify.
-    #[error("verification error")]
+    #[snafu(display("verification error"))]
     VerificationError,
     /// This error occurs when the setup is too small.
-    #[error("setup is too small: the setup is {actual}, but the proof requires a setup of size {required}")]
+    #[snafu(display("setup is too small: the setup is {actual}, but the proof requires a setup of size {required}"))]
     SmallSetup { actual: usize, required: usize },
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -65,9 +65,9 @@ impl<S: Scalar> SumcheckProof<S> {
         // This challenge is in order to keep transcript messages grouped. (This simplifies the Solidity implementation.)
         transcript.scalar_challenge_as_be::<S>();
         if self.evaluations.len() != polynomial_info.num_variables {
-            return Err(ProofError::VerificationError(
-                "invalid number of evaluations",
-            ));
+            return Err(ProofError::VerificationError {
+                error: "invalid number of evaluations",
+            });
         }
         let mut evaluation_point = Vec::with_capacity(polynomial_info.num_variables);
         for round_index in 0..polynomial_info.num_variables {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/subclaim.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/subclaim.rs
@@ -25,14 +25,14 @@ impl<S: Scalar> Subclaim<S> {
         for round_index in 0..num_vars {
             let round_evaluation = &evaluations[round_index];
             if round_evaluation.len() != max_multiplicands + 1 {
-                return Err(ProofError::VerificationError(
-                    "round evaluation length does not match max multiplicands",
-                ));
+                return Err(ProofError::VerificationError {
+                    error: "round evaluation length does not match max multiplicands",
+                });
             }
             if expected_sum != round_evaluation[0] + round_evaluation[1] {
-                return Err(ProofError::VerificationError(
-                    "round evaluation does not match claimed sum",
-                ));
+                return Err(ProofError::VerificationError {
+                    error: "round evaluation does not match claimed sum",
+                });
             }
             expected_sum = interpolate_uni_poly(round_evaluation, evaluation_point[round_index]);
         }

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -60,10 +60,9 @@ impl DynProofExprBuilder<'_> {
             Expression::Binary { op, left, right } => self.visit_binary_expr(*op, left, right),
             Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
             Expression::Aggregation { op, expr } => self.visit_aggregate_expr(*op, expr),
-            _ => Err(ConversionError::Unprovable(format!(
-                "Expression {:?} is not supported yet",
-                expr
-            ))),
+            _ => Err(ConversionError::Unprovable {
+                error: format!("Expression {:?} is not supported yet", expr),
+            }),
         }
     }
 
@@ -73,7 +72,9 @@ impl DynProofExprBuilder<'_> {
     ) -> Result<DynProofExpr<C>, ConversionError> {
         Ok(DynProofExpr::Column(ColumnExpr::new(
             *self.column_mapping.get(&identifier).ok_or(
-                ConversionError::MissingColumnWithoutTable(Box::new(identifier)),
+                ConversionError::MissingColumnWithoutTable {
+                    identifier: Box::new(identifier),
+                },
             )?,
         )))
     }
@@ -88,9 +89,12 @@ impl DynProofExprBuilder<'_> {
             Literal::Int128(i) => Ok(DynProofExpr::new_literal(LiteralValue::Int128(*i))),
             Literal::Decimal(d) => {
                 let scale = d.scale();
-                let precision = Precision::new(d.precision()).map_err(|_| {
-                    DecimalConversionError(InvalidPrecision(d.precision().to_string()))
-                })?;
+                let precision =
+                    Precision::new(d.precision()).map_err(|_| DecimalConversionError {
+                        source: InvalidPrecision {
+                            error: d.precision().to_string(),
+                        },
+                    })?;
                 Ok(DynProofExpr::new_literal(LiteralValue::Decimal75(
                     precision,
                     scale,
@@ -105,10 +109,10 @@ impl DynProofExprBuilder<'_> {
                 let timestamp = match its.timeunit() {
                     PoSQLTimeUnit::Nanosecond => {
                         its.timestamp().timestamp_nanos_opt().ok_or_else(|| {
-                                PoSQLTimestampError::UnsupportedPrecision("Timestamp out of range: 
+                                PoSQLTimestampError::UnsupportedPrecision{ error: "Timestamp out of range: 
                                 Valid nanosecond timestamps must be between 1677-09-21T00:12:43.145224192 
                                 and 2262-04-11T23:47:16.854775807.".to_owned()
-                            )
+                        }
                         })?
                     }
                     PoSQLTimeUnit::Microsecond => its.timestamp().timestamp_micros(),
@@ -183,10 +187,9 @@ impl DynProofExprBuilder<'_> {
                 let right = self.visit_expr(right);
                 DynProofExpr::try_new_multiply(left?, right?)
             }
-            BinaryOperator::Division => Err(ConversionError::Unprovable(format!(
-                "Binary operator {:?} is not supported at this location",
-                op
-            ))),
+            BinaryOperator::Division => Err(ConversionError::Unprovable {
+                error: format!("Binary operator {:?} is not supported at this location", op),
+            }),
         }
     }
 
@@ -196,23 +199,27 @@ impl DynProofExprBuilder<'_> {
         expr: &Expression,
     ) -> Result<DynProofExpr<C>, ConversionError> {
         if self.in_agg_scope {
-            return Err(ConversionError::InvalidExpression(
-                "nested aggregations are invalid".to_string(),
-            ));
+            return Err(ConversionError::InvalidExpression {
+                expression: "nested aggregations are invalid".to_string(),
+            });
         }
         let expr = DynProofExprBuilder::new_agg(self.column_mapping).visit_expr(expr)?;
         match (op, expr.data_type().is_numeric()) {
             (AggregationOperator::Count, _) | (AggregationOperator::Sum, true) => {
                 Ok(DynProofExpr::new_aggregate(op, expr))
             }
-            (AggregationOperator::Sum, false) => Err(ConversionError::InvalidExpression(format!(
-                "Aggregation operator {:?} doesn't work with non-numeric types",
-                op
-            ))),
-            _ => Err(ConversionError::Unprovable(format!(
-                "Aggregation operator {:?} is not supported at this location",
-                op
-            ))),
+            (AggregationOperator::Sum, false) => Err(ConversionError::InvalidExpression {
+                expression: format!(
+                    "Aggregation operator {:?} doesn't work with non-numeric types",
+                    op
+                ),
+            }),
+            _ => Err(ConversionError::Unprovable {
+                error: format!(
+                    "Aggregation operator {:?} is not supported at this location",
+                    op
+                ),
+            }),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -6,12 +6,12 @@ use proof_of_sql_parser::{
     intermediate_decimal::IntermediateDecimalError, posql_time::PoSQLTimestampError, Identifier,
     ResourceId,
 };
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors from converting an intermediate AST into a provable AST.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum ConversionError {
-    #[error("Column '{identifier}' was not found in table '{resource_id}'")]
+    #[snafu(display("Column '{identifier}' was not found in table '{resource_id}'"))]
     /// The column is missing in the table
     MissingColumn {
         /// The missing column identifier
@@ -20,14 +20,14 @@ pub enum ConversionError {
         resource_id: Box<ResourceId>,
     },
 
-    #[error("Column '{identifier}' was not found")]
+    #[snafu(display("Column '{identifier}' was not found"))]
     /// The column is missing (without table information)
     MissingColumnWithoutTable {
         /// The missing column identifier
         identifier: Box<Identifier>,
     },
 
-    #[error("Expected '{expected}' but found '{actual}'")]
+    #[snafu(display("Expected '{expected}' but found '{actual}'"))]
     /// Invalid data type received
     InvalidDataType {
         /// Expected data type
@@ -36,7 +36,7 @@ pub enum ConversionError {
         actual: ColumnType,
     },
 
-    #[error("Left side has '{left_type}' type but right side has '{right_type}' type")]
+    #[snafu(display("Left side has '{left_type}' type but right side has '{right_type}' type"))]
     /// Data types do not match
     DataTypeMismatch {
         /// The left side datatype
@@ -45,7 +45,7 @@ pub enum ConversionError {
         right_type: String,
     },
 
-    #[error("Columns have different lengths: {len_a} != {len_b}")]
+    #[snafu(display("Columns have different lengths: {len_a} != {len_b}"))]
     /// Two columns do not have the same length
     DifferentColumnLength {
         /// The length of the first column
@@ -54,81 +54,83 @@ pub enum ConversionError {
         len_b: usize,
     },
 
-    #[error("Multiple result columns with the same alias '{alias}' have been found.")]
+    #[snafu(display("Multiple result columns with the same alias '{alias}' have been found."))]
     /// Duplicate alias in result columns
     DuplicateResultAlias {
         /// The duplicate alias
         alias: String,
     },
 
-    #[error("A WHERE clause must has boolean type. It is currently of type '{datatype}'.")]
+    #[snafu(display(
+        "A WHERE clause must has boolean type. It is currently of type '{datatype}'."
+    ))]
     /// WHERE clause is not boolean
     NonbooleanWhereClause {
         /// The actual datatype of the WHERE clause
         datatype: ColumnType,
     },
 
-    #[error("Invalid order by: alias '{alias}' does not appear in the result expressions.")]
+    #[snafu(display(
+        "Invalid order by: alias '{alias}' does not appear in the result expressions."
+    ))]
     /// ORDER BY clause references a non-existent alias
     InvalidOrderBy {
         /// The non-existent alias in the ORDER BY clause
         alias: String,
     },
 
-    #[error("Invalid group by: column '{column}' must appear in the group by expression.")]
+    #[snafu(display(
+        "Invalid group by: column '{column}' must appear in the group by expression."
+    ))]
     /// GROUP BY clause references a non-existent column
     InvalidGroupByColumnRef {
         /// The non-existent column in the GROUP BY clause
         column: String,
     },
 
-    #[error("Invalid expression: {expression}")]
+    #[snafu(display("Invalid expression: {expression}"))]
     /// General error for invalid expressions
     InvalidExpression {
         /// The invalid expression error
         expression: String,
     },
 
-    #[error("Encountered parsing error: {error}")]
+    #[snafu(display("Encountered parsing error: {error}"))]
     /// General parsing error
     ParseError {
         /// The underlying error
         error: String,
     },
 
-    #[error(transparent)]
+    #[snafu(transparent)]
     /// Errors related to decimal operations
     DecimalConversionError {
         /// The underlying source error
-        #[from]
         source: DecimalError,
     },
 
     /// Errors related to timestamp parsing
-    #[error("Timestamp conversion error: {source}")]
+    #[snafu(context(false), display("Timestamp conversion error: {source}"))]
     TimestampConversionError {
         /// The underlying source error
-        #[from]
         source: PoSQLTimestampError,
     },
 
     /// Errors related to column operations
-    #[error(transparent)]
+    #[snafu(transparent)]
     ColumnOperationError {
         /// The underlying source error
-        #[from]
         source: ColumnOperationError,
     },
 
     /// Errors related to postprocessing
-    #[error(transparent)]
+    #[snafu(transparent)]
     PostprocessingError {
         /// The underlying source error
-        #[from]
         source: crate::sql::postprocessing::PostprocessingError,
     },
 
-    #[error("Query not provable because: {error}")]
+    #[snafu(display("Query not provable because: {error}"))]
     /// Query requires unprovable feature
     Unprovable {
         /// The underlying error

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -229,8 +229,9 @@ impl<'a> QueryContextBuilder<'a> {
         let table_ref = self.context.get_table_ref();
         let column_type = self.schema_accessor.lookup_column(*table_ref, column_name);
 
-        let column_type = column_type.ok_or_else(|| {
-            ConversionError::MissingColumn(Box::new(column_name), Box::new(table_ref.resource_id()))
+        let column_type = column_type.ok_or_else(|| ConversionError::MissingColumn {
+            identifier: Box::new(column_name),
+            resource_id: Box::new(table_ref.resource_id()),
         })?;
 
         let column = ColumnRef::new(*table_ref, column_name, column_type);
@@ -306,9 +307,9 @@ fn check_dtypes(
     if type_check_binary_operation(&left_dtype, &right_dtype, binary_operator) {
         Ok(())
     } else {
-        Err(ConversionError::DataTypeMismatch(
-            left_dtype.to_string(),
-            right_dtype.to_string(),
-        ))
+        Err(ConversionError::DataTypeMismatch {
+            left_type: left_dtype.to_string(),
+            right_type: right_dtype.to_string(),
+        })
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1591,39 +1591,39 @@ fn we_can_parse_arithmetic_expression_within_aggregations_in_the_result_expr() {
 fn we_cannot_use_non_grouped_columns_outside_agg() {
     assert!(matches!(
         query!(select: ["i"], group: ["s"], should_err: true),
-        ConversionError::PostprocessingError(
-            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(_)
-        )
+        ConversionError::PostprocessingError {
+            source: PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. }
+        }
     ));
     assert!(matches!(
         query!(select: ["sum(i)", "i"], group: ["s"], should_err: true),
-        ConversionError::PostprocessingError(
-            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(_)
-        )
+        ConversionError::PostprocessingError {
+            source: PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. }
+        }
     ));
     assert!(matches!(
         query!(select: ["min(i) + i"], group: ["s"], should_err: true),
-        ConversionError::PostprocessingError(
-            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(_)
-        )
+        ConversionError::PostprocessingError {
+            source: PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. }
+        }
     ));
     assert!(matches!(
         query!(select: ["2 * i", "min(i)"], group: ["s"], should_err: true),
-        ConversionError::PostprocessingError(
-            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(_)
-        )
+        ConversionError::PostprocessingError {
+            source: PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. }
+        }
     ));
     assert!(matches!(
         query!(select: ["2 * i", "min(i)"], should_err: true),
-        ConversionError::InvalidGroupByColumnRef(_)
+        ConversionError::InvalidGroupByColumnRef { .. }
     ));
     assert!(matches!(
         query!(select: ["sum(i)", "i"], should_err: true),
-        ConversionError::InvalidGroupByColumnRef(_)
+        ConversionError::InvalidGroupByColumnRef { .. }
     ));
     assert!(matches!(
         query!(select: ["max(i) + 2 * i"], should_err: true),
-        ConversionError::InvalidGroupByColumnRef(_)
+        ConversionError::InvalidGroupByColumnRef { .. }
     ));
 }
 
@@ -1631,31 +1631,31 @@ fn we_cannot_use_non_grouped_columns_outside_agg() {
 fn varchar_column_is_not_compatible_with_integer_column() {
     assert_eq!(
         query!(select: ["-123 * s"], should_err: true),
-        ConversionError::DataTypeMismatch(
-            ColumnType::BigInt.to_string(),
-            ColumnType::VarChar.to_string()
-        )
+        ConversionError::DataTypeMismatch {
+            left_type: ColumnType::BigInt.to_string(),
+            right_type: ColumnType::VarChar.to_string()
+        }
     );
     assert_eq!(
         query!(select: ["i - s"], should_err: true),
-        ConversionError::DataTypeMismatch(
-            ColumnType::BigInt.to_string(),
-            ColumnType::VarChar.to_string()
-        )
+        ConversionError::DataTypeMismatch {
+            left_type: ColumnType::BigInt.to_string(),
+            right_type: ColumnType::VarChar.to_string()
+        }
     );
     assert_eq!(
         query!(select: ["s"], filter: "'abc' = i", should_err: true),
-        ConversionError::DataTypeMismatch(
-            ColumnType::VarChar.to_string(),
-            ColumnType::BigInt.to_string(),
-        )
+        ConversionError::DataTypeMismatch {
+            left_type: ColumnType::VarChar.to_string(),
+            right_type: ColumnType::BigInt.to_string(),
+        }
     );
     assert_eq!(
         query!(select: ["s"], filter: "'abc' != i", should_err: true),
-        ConversionError::DataTypeMismatch(
-            ColumnType::VarChar.to_string(),
-            ColumnType::BigInt.to_string(),
-        )
+        ConversionError::DataTypeMismatch {
+            left_type: ColumnType::VarChar.to_string(),
+            right_type: ColumnType::BigInt.to_string(),
+        }
     );
 }
 
@@ -1663,10 +1663,10 @@ fn varchar_column_is_not_compatible_with_integer_column() {
 fn arithmetic_operations_are_not_allowed_with_varchar_column() {
     assert_eq!(
         query!(select: ["s - s1"], should_err: true),
-        ConversionError::DataTypeMismatch(
-            ColumnType::VarChar.to_string(),
-            ColumnType::VarChar.to_string()
-        )
+        ConversionError::DataTypeMismatch {
+            left_type: ColumnType::VarChar.to_string(),
+            right_type: ColumnType::VarChar.to_string()
+        }
     );
 }
 
@@ -1866,7 +1866,9 @@ fn nested_aggregations_are_not_supported() {
     for perm_aggs in supported_agg.iter().permutations(2) {
         assert_eq!(
             query!(select: [format!("{}({}(i))", perm_aggs[0], perm_aggs[1])], should_err: true),
-            ConversionError::InvalidExpression("nested aggregations are not supported".to_string())
+            ConversionError::InvalidExpression {
+                expression: "nested aggregations are not supported".to_string()
+            }
         );
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -33,9 +33,9 @@ impl<'a> WhereExprBuilder<'a> {
                 // Ensure that the expression is a boolean expression
                 match expr_plan.data_type() {
                     ColumnType::Boolean => Ok(expr_plan),
-                    _ => Err(ConversionError::NonbooleanWhereClause(
-                        expr_plan.data_type(),
-                    )),
+                    _ => Err(ConversionError::NonbooleanWhereClause {
+                        datatype: expr_plan.data_type(),
+                    }),
                 }
             })
             .transpose()

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -261,7 +261,7 @@ fn we_can_not_have_missing_column_as_where_clause() {
     let res = builder.build::<RistrettoPoint>(Some(expr_missing));
     assert!(matches!(
         res,
-        Result::Err(ConversionError::MissingColumnWithoutTable(_))
+        Result::Err(ConversionError::MissingColumnWithoutTable { .. })
     ));
 }
 
@@ -275,7 +275,7 @@ fn we_can_not_have_non_boolean_column_as_where_clause() {
     let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
     assert!(matches!(
         res,
-        Result::Err(ConversionError::NonbooleanWhereClause(_))
+        Result::Err(ConversionError::NonbooleanWhereClause { .. })
     ));
 }
 
@@ -289,7 +289,7 @@ fn we_can_not_have_non_boolean_literal_as_where_clause() {
     let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
     assert!(matches!(
         res,
-        Result::Err(ConversionError::NonbooleanWhereClause(_))
+        Result::Err(ConversionError::NonbooleanWhereClause { .. })
     ));
 }
 
@@ -308,7 +308,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
             t.schema_id(),
             &accessor,
         ),
-        Err(ConversionError::DataTypeMismatch(_, _))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 
@@ -327,7 +327,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
             t.schema_id(),
             &accessor,
         ),
-        Err(ConversionError::DataTypeMismatch(_, _))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -1,57 +1,53 @@
 use proof_of_sql_parser::Identifier;
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Errors in postprocessing
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum PostprocessingError {
     /// Error in slicing due to slice index beyond usize
-    #[error("Error in slicing due to slice index beyond usize {index}")]
+    #[snafu(display("Error in slicing due to slice index beyond usize {index}"))]
     InvalidSliceIndex {
         /// The overflowing index value
         index: i128,
     },
     /// Column not found
-    #[error("Column not found: {column}")]
+    #[snafu(display("Column not found: {column}"))]
     ColumnNotFound {
         /// The column which is not found
         column: String,
     },
     /// Errors in evaluation of `Expression`s
-    #[error(transparent)]
+    #[snafu(transparent)]
     ExpressionEvaluationError {
         /// The underlying source error
-        #[from]
         source: crate::base::database::ExpressionEvaluationError,
     },
     /// Errors in constructing `OwnedTable`
-    #[error(transparent)]
+    #[snafu(transparent)]
     OwnedTableError {
         /// The underlying source error
-        #[from]
         source: crate::base::database::OwnedTableError,
     },
     /// GROUP BY clause references a column not in a group by expression outside aggregate functions
-    #[error("Invalid group by: column '{column}' must not appear outside aggregate functions or `GROUP BY` clause.")]
+    #[snafu(display("Invalid group by: column '{column}' must not appear outside aggregate functions or `GROUP BY` clause."))]
     IdentifierNotInAggregationOperatorOrGroupByClause {
         /// The column identifier
         column: Identifier,
     },
     /// Errors in aggregate columns
-    #[error(transparent)]
+    #[snafu(transparent)]
     AggregateColumnsError {
         /// The underlying source error
-        #[from]
         source: crate::base::database::group_by_util::AggregateColumnsError,
     },
     /// Errors in `OwnedColumn`
-    #[error(transparent)]
+    #[snafu(transparent)]
     OwnedColumnError {
         /// The underlying source error
-        #[from]
         source: crate::base::database::OwnedColumnError,
     },
     /// Nested aggregation in `GROUP BY` clause
-    #[error("Nested aggregation in `GROUP BY` clause: {error}")]
+    #[snafu(display("Nested aggregation in `GROUP BY` clause: {error}"))]
     NestedAggregationInGroupByClause {
         /// The nested aggregation error
         error: String,

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -5,29 +5,57 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PostprocessingError {
     /// Error in slicing due to slice index beyond usize
-    #[error("Error in slicing due to slice index beyond usize {0}")]
-    InvalidSliceIndex(i128),
+    #[error("Error in slicing due to slice index beyond usize {index}")]
+    InvalidSliceIndex {
+        /// The overflowing index value
+        index: i128,
+    },
     /// Column not found
-    #[error("Column not found: {0}")]
-    ColumnNotFound(String),
+    #[error("Column not found: {column}")]
+    ColumnNotFound {
+        /// The column which is not found
+        column: String,
+    },
     /// Errors in evaluation of `Expression`s
     #[error(transparent)]
-    ExpressionEvaluationError(#[from] crate::base::database::ExpressionEvaluationError),
+    ExpressionEvaluationError {
+        /// The underlying source error
+        #[from]
+        source: crate::base::database::ExpressionEvaluationError,
+    },
     /// Errors in constructing `OwnedTable`
     #[error(transparent)]
-    OwnedTableError(#[from] crate::base::database::OwnedTableError),
+    OwnedTableError {
+        /// The underlying source error
+        #[from]
+        source: crate::base::database::OwnedTableError,
+    },
     /// GROUP BY clause references a column not in a group by expression outside aggregate functions
-    #[error("Invalid group by: column '{0}' must not appear outside aggregate functions or `GROUP BY` clause.")]
-    IdentifierNotInAggregationOperatorOrGroupByClause(Identifier),
+    #[error("Invalid group by: column '{column}' must not appear outside aggregate functions or `GROUP BY` clause.")]
+    IdentifierNotInAggregationOperatorOrGroupByClause {
+        /// The column identifier
+        column: Identifier,
+    },
     /// Errors in aggregate columns
     #[error(transparent)]
-    AggregateColumnsError(#[from] crate::base::database::group_by_util::AggregateColumnsError),
+    AggregateColumnsError {
+        /// The underlying source error
+        #[from]
+        source: crate::base::database::group_by_util::AggregateColumnsError,
+    },
     /// Errors in `OwnedColumn`
     #[error(transparent)]
-    OwnedColumnError(#[from] crate::base::database::OwnedColumnError),
+    OwnedColumnError {
+        /// The underlying source error
+        #[from]
+        source: crate::base::database::OwnedColumnError,
+    },
     /// Nested aggregation in `GROUP BY` clause
-    #[error("Nested aggregation in `GROUP BY` clause: {0}")]
-    NestedAggregationInGroupByClause(String),
+    #[error("Nested aggregation in `GROUP BY` clause: {error}")]
+    NestedAggregationInGroupByClause {
+        /// The nested aggregation error
+        error: String,
+    },
 }
 
 /// Result type for postprocessing

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -115,9 +115,9 @@ fn check_and_get_aggregation_and_remainder(
         .cloned()
         .collect::<IndexSet<_>>();
     if contains_nested_aggregation(&expr.expr, false) {
-        return Err(PostprocessingError::NestedAggregationInGroupByClause(
-            format!("Nested aggregations found {:?}", expr.expr),
-        ));
+        return Err(PostprocessingError::NestedAggregationInGroupByClause {
+            error: format!("Nested aggregations found {:?}", expr.expr),
+        });
     }
     if free_identifiers.is_subset(&group_by_identifier_set) {
         let remainder = get_aggregate_and_remainder_expressions(*expr.expr, aggregation_expr_map);
@@ -130,7 +130,11 @@ fn check_and_get_aggregation_and_remainder(
             .difference(&group_by_identifier_set)
             .next()
             .unwrap();
-        Err(PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(*diff))
+        Err(
+            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause {
+                column: *diff,
+            },
+        )
     }
 }
 
@@ -198,10 +202,11 @@ impl<S: Scalar> PostprocessingStep<S> for GroupByPostprocessing {
             .group_by_identifiers
             .iter()
             .map(|id| {
-                let column = owned_table
-                    .inner_table()
-                    .get(id)
-                    .ok_or(PostprocessingError::ColumnNotFound(id.to_string()))?;
+                let column = owned_table.inner_table().get(id).ok_or(
+                    PostprocessingError::ColumnNotFound {
+                        column: id.to_string(),
+                    },
+                )?;
                 Ok(Column::<S>::from_owned_column(column, &alloc))
             })
             .collect::<PostprocessingResult<Vec<_>>>()?;

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
@@ -19,7 +19,7 @@ fn we_cannot_have_invalid_group_bys() {
     let res = GroupByPostprocessing::try_new(vec![ident("a")], vec![aliased_expr(expr, "res")]);
     assert!(matches!(
         res,
-        Err(PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause(_))
+        Err(PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. })
     ));
 
     // Nested aggregation
@@ -27,7 +27,7 @@ fn we_cannot_have_invalid_group_bys() {
     let res = GroupByPostprocessing::try_new(vec![ident("a")], vec![aliased_expr(expr, "res")]);
     assert!(matches!(
         res,
-        Err(PostprocessingError::NestedAggregationInGroupByClause(_))
+        Err(PostprocessingError::NestedAggregationInGroupByClause { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
@@ -36,9 +36,9 @@ impl<S: Scalar> PostprocessingStep<S> for OrderByPostprocessing {
                         owned_table
                             .inner_table()
                             .get(&order_by.expr)
-                            .ok_or(PostprocessingError::ColumnNotFound(
-                                order_by.expr.to_string(),
-                            ))?
+                            .ok_or(PostprocessingError::ColumnNotFound {
+                                column: order_by.expr.to_string(),
+                            })?
                             .clone(),
                         order_by.direction,
                     ))

--- a/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
@@ -44,10 +44,16 @@ impl<S: Scalar> PostprocessingStep<S> for SlicePostprocessing {
         };
         // The `possible_ending_row` is NOT inclusive.
         let possible_ending_row = (possible_starting_row + limit as i128).min(num_rows as i128);
-        let starting_row = usize::try_from(possible_starting_row)
-            .map_err(|_| PostprocessingError::InvalidSliceIndex(possible_starting_row))?;
-        let ending_row = usize::try_from(possible_ending_row)
-            .map_err(|_| PostprocessingError::InvalidSliceIndex(possible_ending_row))?;
+        let starting_row = usize::try_from(possible_starting_row).map_err(|_| {
+            PostprocessingError::InvalidSliceIndex {
+                index: possible_starting_row,
+            }
+        })?;
+        let ending_row = usize::try_from(possible_ending_row).map_err(|_| {
+            PostprocessingError::InvalidSliceIndex {
+                index: possible_ending_row,
+            }
+        })?;
         Ok(OwnedTable::<S>::try_from_iter(
             owned_table
                 .into_inner()

--- a/crates/proof-of-sql/src/sql/proof/count_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/count_builder.rs
@@ -24,9 +24,9 @@ impl<'a> CountBuilder<'a> {
     /// pass of verification.
     pub fn consume_bit_distribution(&mut self) -> Result<BitDistribution, ProofError> {
         if self.bit_distributions.is_empty() {
-            Err(ProofError::VerificationError(
-                "expected prover to provide bit distribution",
-            ))
+            Err(ProofError::VerificationError {
+                error: "expected prover to provide bit distribution",
+            })
         } else {
             let res = self.bit_distributions[0].clone();
             self.bit_distributions = &self.bit_distributions[1..];
@@ -57,9 +57,9 @@ impl<'a> CountBuilder<'a> {
 
     pub fn counts(&self) -> Result<ProofCounts, ProofError> {
         if !self.bit_distributions.is_empty() {
-            return Err(ProofError::VerificationError(
-                "incorrect number of bit distributions provided",
-            ));
+            return Err(ProofError::VerificationError {
+                error: "incorrect number of bit distributions provided",
+            });
         }
         Ok(self.counts)
     }

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -155,7 +155,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         // validate bit decompositions
         for dist in self.bit_distributions.iter() {
             if !dist.is_valid() {
-                Err(ProofError::VerificationError("invalid bit distributions"))?;
+                Err(ProofError::VerificationError {
+                    error: "invalid bit distributions",
+                })?;
             }
         }
 
@@ -168,7 +170,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // verify sizes
         if !self.validate_sizes(&counts, result) {
-            Err(ProofError::VerificationError("invalid proof size"))?;
+            Err(ProofError::VerificationError {
+                error: "invalid proof size",
+            })?;
         }
 
         // construct a transcript for the proof
@@ -254,9 +258,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // perform the evaluation check of the sumcheck polynomial
         if builder.sumcheck_evaluation() != subclaim.expected_evaluation {
-            Err(ProofError::VerificationError(
-                "sumcheck evaluation check failed",
-            ))?;
+            Err(ProofError::VerificationError {
+                error: "sumcheck evaluation check failed",
+            })?;
         }
 
         // finally, check the MLE evaluations with the inner product proof
@@ -272,8 +276,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 table_length,
                 setup,
             )
-            .map_err(|_e| {
-                ProofError::VerificationError("Inner product proof of MLE evaluations failed")
+            .map_err(|_e| ProofError::VerificationError {
+                error: "Inner product proof of MLE evaluations failed",
             })?;
 
         let mut verification_hash = [0u8; 32];

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -29,10 +29,18 @@ pub enum QueryError {
     MiscellaneousEvaluationError,
     /// The proof failed to verify.
     #[error(transparent)]
-    ProofError(#[from] ProofError),
+    ProofError {
+        /// The underlying source error
+        #[from]
+        source: ProofError,
+    },
     /// The table data was invalid. This should never happen because this should get caught by the verifier before reaching this point.
     #[error(transparent)]
-    InvalidTable(#[from] OwnedTableError),
+    InvalidTable {
+        /// The underlying source error
+        #[from]
+        source: OwnedTableError,
+    },
 }
 
 /// The verified results of a query along with metadata produced by verification

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -5,40 +5,38 @@ use crate::base::{
 };
 #[cfg(feature = "arrow")]
 use arrow::{error::ArrowError, record_batch::RecordBatch};
-use thiserror::Error;
+use snafu::Snafu;
 
 /// Verifiable query errors
-#[derive(Error, Debug)]
+#[derive(Snafu, Debug)]
 pub enum QueryError {
     /// The query result overflowed. This does not mean that the verification failed.
     /// This just means that the database was supposed to respond with a result that was too large.
-    #[error("Overflow error")]
+    #[snafu(display("Overflow error"))]
     Overflow,
     /// The query result string could not be decoded. This does not mean that the verification failed.
     /// This just means that the database was supposed to respond with a string that was not valid UTF-8.
-    #[error("String decode error")]
+    #[snafu(display("String decode error"))]
     InvalidString,
     /// Decoding errors other than overflow and invalid string.
-    #[error("Miscellaneous decoding error")]
+    #[snafu(display("Miscellaneous decoding error"))]
     MiscellaneousDecodingError,
     /// Indexes are invalid.
-    #[error("Invalid indexes")]
+    #[snafu(display("Invalid indexes"))]
     InvalidIndexes,
     /// Miscellaneous evaluation error.
-    #[error("Miscellaneous evaluation error")]
+    #[snafu(display("Miscellaneous evaluation error"))]
     MiscellaneousEvaluationError,
     /// The proof failed to verify.
-    #[error(transparent)]
+    #[snafu(transparent)]
     ProofError {
         /// The underlying source error
-        #[from]
         source: ProofError,
     },
     /// The table data was invalid. This should never happen because this should get caught by the verifier before reaching this point.
-    #[error(transparent)]
+    #[snafu(transparent)]
     InvalidTable {
         /// The underlying source error
-        #[from]
         source: OwnedTableError,
     },
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -120,9 +120,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         // handle the empty case
         if expr.is_empty(accessor) {
             if self.provable_result.is_some() || self.proof.is_some() {
-                return Err(ProofError::VerificationError(
-                    "zero sumcheck variables but non-empty result",
-                ))?;
+                return Err(ProofError::VerificationError {
+                    error: "zero sumcheck variables but non-empty result",
+                })?;
             }
 
             let result_fields = expr.get_column_result_fields();
@@ -131,9 +131,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         }
 
         if self.provable_result.is_none() || self.proof.is_none() {
-            return Err(ProofError::VerificationError(
-                "non-zero sumcheck variables but empty result",
-            ))?;
+            return Err(ProofError::VerificationError {
+                error: "non-zero sumcheck variables but empty result",
+            })?;
         }
 
         self.proof.as_ref().unwrap().verify(

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -107,7 +107,7 @@ fn decimal_column_type_issues_error_out_when_producing_provable_ast() {
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_add(column(t, "a", &accessor), const_bigint::<RistrettoPoint>(1)),
-        Err(ConversionError::DataTypeMismatch(..))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/bitwise_verification.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/bitwise_verification.rs
@@ -45,9 +45,9 @@ pub fn verify_constant_sign_decomposition<S: Scalar>(
     if lhs == rhs {
         Ok(())
     } else {
-        Err(ProofError::VerificationError(
-            "constant sign bitwise decomposition is invalid",
-        ))
+        Err(ProofError::VerificationError {
+            error: "constant sign bitwise decomposition is invalid",
+        })
     }
 }
 
@@ -67,8 +67,8 @@ pub fn verify_constant_abs_decomposition<S: Scalar>(
     if S::from(dist.constant_part()) * t == eval {
         Ok(())
     } else {
-        Err(ProofError::VerificationError(
-            "constant absolute bitwise decomposition is invalid",
-        ))
+        Err(ProofError::VerificationError {
+            error: "constant absolute bitwise decomposition is invalid",
+        })
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -40,7 +40,10 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     let lhs_len = lhs.len();
     let rhs_len = rhs.len();
     if lhs_len != rhs_len {
-        return Err(ConversionError::DifferentColumnLength(lhs_len, rhs_len));
+        return Err(ConversionError::DifferentColumnLength {
+            len_a: lhs_len,
+            len_b: rhs_len,
+        });
     }
     let lhs_type = lhs.column_type();
     let rhs_type = rhs.column_type();
@@ -50,10 +53,10 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
         BinaryOperator::LessThanOrEqual
     };
     if !type_check_binary_operation(&lhs_type, &rhs_type, operator) {
-        return Err(ConversionError::DataTypeMismatch(
-            lhs_type.to_string(),
-            rhs_type.to_string(),
-        ));
+        return Err(ConversionError::DataTypeMismatch {
+            left_type: lhs_type.to_string(),
+            right_type: rhs_type.to_string(),
+        });
     }
     let max_scale = std::cmp::max(lhs_scale, rhs_scale);
     let lhs_upscale = max_scale - lhs_scale;
@@ -72,9 +75,11 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
         );
         // Check if the precision is valid
         let _max_precision = Precision::new(max_precision_value).map_err(|_| {
-            ConversionError::DecimalConversionError(DecimalError::InvalidPrecision(
-                max_precision_value.to_string(),
-            ))
+            ConversionError::DecimalConversionError {
+                source: DecimalError::InvalidPrecision {
+                    error: max_precision_value.to_string(),
+                },
+            }
         })?;
     }
     unchecked_subtract_impl(

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -74,10 +74,10 @@ impl<C: Commitment> DynProofExpr<C> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if !type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Equal) {
-            Err(ConversionError::DataTypeMismatch(
-                lhs_datatype.to_string(),
-                rhs_datatype.to_string(),
-            ))
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
         } else {
             Ok(Self::Equals(EqualsExpr::new(Box::new(lhs), Box::new(rhs))))
         }
@@ -95,10 +95,10 @@ impl<C: Commitment> DynProofExpr<C> {
             &rhs_datatype,
             BinaryOperator::LessThanOrEqual,
         ) {
-            Err(ConversionError::DataTypeMismatch(
-                lhs_datatype.to_string(),
-                rhs_datatype.to_string(),
-            ))
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
         } else {
             Ok(Self::Inequality(InequalityExpr::new(
                 Box::new(lhs),
@@ -113,10 +113,10 @@ impl<C: Commitment> DynProofExpr<C> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if !type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Add) {
-            Err(ConversionError::DataTypeMismatch(
-                lhs_datatype.to_string(),
-                rhs_datatype.to_string(),
-            ))
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
         } else {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
@@ -131,10 +131,10 @@ impl<C: Commitment> DynProofExpr<C> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if !type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Subtract) {
-            Err(ConversionError::DataTypeMismatch(
-                lhs_datatype.to_string(),
-                rhs_datatype.to_string(),
-            ))
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
         } else {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
@@ -149,10 +149,10 @@ impl<C: Commitment> DynProofExpr<C> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if !type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Multiply) {
-            Err(ConversionError::DataTypeMismatch(
-                lhs_datatype.to_string(),
-                rhs_datatype.to_string(),
-            ))
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
         } else {
             Ok(Self::Multiply(MultiplyExpr::new(
                 Box::new(lhs),

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -304,7 +304,7 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
             const_scalar::<RistrettoPoint, Curve25519Scalar>(Curve25519Scalar::ONE),
             false
         ),
-        Err(ConversionError::DataTypeMismatch(_, _))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -79,7 +79,7 @@ fn decimal_column_type_issues_error_out_when_producing_provable_ast() {
             column(t, "a", &accessor),
             const_bigint::<RistrettoPoint>(1)
         ),
-        Err(ConversionError::DataTypeMismatch(..))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -20,9 +20,9 @@ use bumpalo::Bump;
 pub fn count_sign(builder: &mut CountBuilder) -> Result<(), ProofError> {
     let dist = builder.consume_bit_distribution()?;
     if !is_within_acceptable_range(&dist) {
-        return Err(ProofError::VerificationError(
-            "bit distribution outside of acceptable range",
-        ));
+        return Err(ProofError::VerificationError {
+            error: "bit distribution outside of acceptable range",
+        });
     }
     if dist.num_varying_bits() == 0 {
         return Ok(());

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -101,10 +101,11 @@ where
                 .collect::<Result<Vec<_>, _>>()?,
         );
         // 3. indexes
-        let indexes_eval = builder
-            .mle_evaluations
-            .result_indexes_evaluation
-            .ok_or(ProofError::VerificationError("invalid indexes"))?;
+        let indexes_eval = builder.mle_evaluations.result_indexes_evaluation.ok_or(
+            ProofError::VerificationError {
+                error: "invalid indexes",
+            },
+        )?;
         // 4. filtered_columns
         let filtered_columns_evals = Vec::from_iter(
             repeat_with(|| builder.consume_result_mle()).take(self.aliased_results.len()),
@@ -229,7 +230,11 @@ fn verify_filter<C: Commitment>(
 
     let chi_eval = match builder.mle_evaluations.result_indexes_evaluation {
         Some(eval) => eval,
-        None => return Err(ProofError::VerificationError("Result indexes not valid.")),
+        None => {
+            return Err(ProofError::VerificationError {
+                error: "Result indexes not valid.",
+            })
+        }
     };
 
     let c_fold_eval = alpha * one_eval + fold_vals(beta, &c_evals);

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -147,6 +147,8 @@ fn we_fail_to_verify_a_basic_filter_with_a_dishonest_prover() {
     let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     assert!(matches!(
         res.verify(&expr, &accessor, &()),
-        Err(QueryError::ProofError(ProofError::VerificationError(_)))
+        Err(QueryError::ProofError {
+            source: ProofError::VerificationError { .. }
+        })
     ));
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -119,10 +119,11 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
             .map(|aliased_expr| aliased_expr.expr.verifier_evaluate(builder, accessor))
             .collect::<Result<Vec<_>, _>>()?;
         // 3. indexes
-        let indexes_eval = builder
-            .mle_evaluations
-            .result_indexes_evaluation
-            .ok_or(ProofError::VerificationError("invalid indexes"))?;
+        let indexes_eval = builder.mle_evaluations.result_indexes_evaluation.ok_or(
+            ProofError::VerificationError {
+                error: "invalid indexes",
+            },
+        )?;
         // 4. filtered_columns
 
         let group_by_result_columns_evals = Vec::from_iter(
@@ -153,15 +154,15 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
                     .iter()
                     .map(|col| table.inner_table().get(&col.column_id()))
                     .collect::<Option<Vec<_>>>()
-                    .ok_or(ProofError::VerificationError(
-                        "Result does not all correct group by columns.",
-                    ))?;
+                    .ok_or(ProofError::VerificationError {
+                        error: "Result does not all correct group by columns.",
+                    })?;
                 if (0..table.num_rows() - 1)
                     .any(|i| compare_indexes_by_owned_columns(&cols, i, i + 1).is_ge())
                 {
-                    Err(ProofError::VerificationError(
-                        "Result of group by not ordered as expected.",
-                    ))?;
+                    Err(ProofError::VerificationError {
+                        error: "Result of group by not ordered as expected.",
+                    })?;
                 }
             }
             None => todo!("GroupByExec currently only supported at top level of query plan."),

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -431,7 +431,7 @@ fn decimal_type_issues_should_cause_provable_ast_to_fail() {
             "sxt".parse().unwrap(),
             &accessor,
         ),
-        Err(ConversionError::DataTypeMismatch(..))
+        Err(ConversionError::DataTypeMismatch { .. })
     ));
 }
 


### PR DESCRIPTION
# Rationale for this change
See https://github.com/spaceandtimelabs/sxt-proof-of-sql/issues/174 for rationale

# What changes are included in this PR?
NOTE: the individual commits may be good to review individually.
- All error enum variants consisting of tuple structs are transformed into named structs. This is necessary because `snafu` does not support tuple structs.
- Every `#[derive(Error)]` is substituted with the analogous `#[derive(Snafu)]`. In particular:
    * `#[error(...)]` attributes are substituted with equivalent `#[snafu(display(...))]` attributes
    * `#[error(transparent)]` attributes are substituted with equivalent `#[snafu(transparent)]` attributes (which also derive the corresponding `From` implementation)
    * For `ConversionError::TimestampConversionError`, the `#[snafu(context(false), display(...))]` attribute is used for deriving a `From` implementation, and at the same time maintain the custom error message
- A `std` feature is introduced for the `proof-of-sql` crate, which in turns activates the `snafu/std` feature. The `std` feature is required for the `posql_db` example, because `Clap` relies on the `std::error::Error` trait.
- `thiserror` still appears in the dependency tree (`cargo tree -i thiserror`), but only as a transitive dependency (via `blitzar`, and dev-dependencies)

# Are these changes tested?
Yes. This PR is a refactoring, and all existing tests pass.
